### PR TITLE
Remove inconsistent "all rights reserved" language

### DIFF
--- a/lib/utils/version_control.dart
+++ b/lib/utils/version_control.dart
@@ -2,7 +2,7 @@
 //  versioncontrol.dart
 //
 //  Created by Alex Tarragó on 04/02/2020.
-//  Copyright © 2020 Dribba GmbH. All rights reserved.
+//  Copyright © 2020 Dribba GmbH.
 //
 
 import 'dart:async';


### PR DESCRIPTION
Based on the information provided, Dribba GmbH does not hold copyright rights "All rights reserved". This pull requests removes the inexact language used to be closer to reality