### PR TITLE
Show string in English when there is no translation available in the local language

### DIFF
--- a/lib/utils/MyLocalizations.dart
+++ b/lib/utils/MyLocalizations.dart
@@ -5,16 +5,15 @@ import 'package:flutter/services.dart';
 
 class MyLocalizations {
   Locale locale;
-  static Map<dynamic, dynamic>? _localisedValues;
-  static Map<dynamic, dynamic>? _englishValues;
+  static Map<dynamic, dynamic> _localisedValues = {};
+  static Map<dynamic, dynamic> _englishValues = {};
 
   MyLocalizations(this.locale) {
     locale = locale;
-    _localisedValues = null;
-    loadEnglishTranslations();
+    _loadEnglishTranslations();
   }
 
-  static Future<void> loadEnglishTranslations() async {
+  static Future<void> _loadEnglishTranslations() async {
     var jsonContent = await rootBundle.loadString('assets/language/en.json');
     _englishValues = json.decode(jsonContent);
   }
@@ -28,15 +27,8 @@ class MyLocalizations {
     return appTranslations;
   }
 
-  String translate(key) {
-    if (_localisedValues != null && _localisedValues![key] != null){
-      return _localisedValues![key];
-    }
-    if (_englishValues != null && _englishValues![key] != null){
-      // Default to English when there is not a translation available in the local language
-      return _englishValues![key];
-    }
-    return '';
+  String translate(String? key) {
+    return _localisedValues[key] ?? _englishValues[key] ?? '';
   }
 
   static String? of(BuildContext context, String? key) {

--- a/lib/utils/MyLocalizations.dart
+++ b/lib/utils/MyLocalizations.dart
@@ -6,10 +6,17 @@ import 'package:flutter/services.dart';
 class MyLocalizations {
   Locale locale;
   static Map<dynamic, dynamic>? _localisedValues;
+  static Map<dynamic, dynamic>? _englishValues;
 
   MyLocalizations(this.locale) {
     locale = locale;
     _localisedValues = null;
+    loadEnglishTranslations();
+  }
+
+  static Future<void> loadEnglishTranslations() async {
+    var jsonContent = await rootBundle.loadString('assets/language/en.json');
+    _englishValues = json.decode(jsonContent);
   }
 
   static Future<MyLocalizations> loadTranslations(Locale locale) async {
@@ -21,10 +28,15 @@ class MyLocalizations {
     return appTranslations;
   }
 
-  String? translate(key) {
-    return _localisedValues != null && _localisedValues![key] != null
-        ? _localisedValues![key]
-        : '';
+  String translate(key) {
+    if (_localisedValues != null && _localisedValues![key] != null){
+      return _localisedValues![key];
+    }
+    if (_englishValues != null && _englishValues![key] != null){
+      // Default to English when there is not a translation available in the local language
+      return _englishValues![key];
+    }
+    return '';
   }
 
   static String? of(BuildContext context, String? key) {


### PR DESCRIPTION

> https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/pull/74#issuecomment-1921158145 Could you implement a fallback to the English version when no translation is available in the specified language? I prefer seeing an English word instead of an empty value.

![image](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/ded8e1bc-a9df-44f5-8450-b2a67f656cc1)
