### PR TITLE
Generate environment specific configuration

### DIFF
--- a/assets/config/dev.json
+++ b/assets/config/dev.json
@@ -1,0 +1,3 @@
+{
+    "baseUrl": "https://madev.creaf.cat"
+}

--- a/assets/config/dev.json
+++ b/assets/config/dev.json
@@ -1,3 +1,3 @@
 {
-    "baseUrl": "https://madev.creaf.cat"
+    "baseUrl": "https://webdev.mosquitoalert.com"
 }

--- a/assets/config/prod.json
+++ b/assets/config/prod.json
@@ -1,0 +1,3 @@
+{
+    "baseUrl": "https://webserver.mosquitoalert.com"
+}

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -22,9 +22,8 @@ import 'package:path_provider/path_provider.dart';
 class ApiSingleton {
   static final _timeoutTimerInSeconds = 10;
 
-  static String devBASEURL = 'https://madev.creaf.cat';
-  static String baseUrl = 'https://webserver.mosquitoalert.com';
-  static String serverUrl = '$baseUrl/api';
+  static String baseUrl = '';
+  static String serverUrl = '';
 
   static String token = 'D4w29W49rMKC7L6vYQ3ua3rd6fQ12YZ6n70P';
 

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -17,6 +17,7 @@ import 'package:mosquito_alert_app/models/topic.dart';
 import 'package:mosquito_alert_app/utils/PushNotificationsManager.dart';
 import 'package:mosquito_alert_app/utils/UserManager.dart';
 import 'package:mosquito_alert_app/utils/Utils.dart';
+import 'package:mosquito_alert_app/app_config.dart';
 import 'package:path_provider/path_provider.dart';
 
 class ApiSingleton {
@@ -76,6 +77,12 @@ class ApiSingleton {
   }
 
   ApiSingleton._internal();
+
+  static Future<void> initialize(String env) async {
+    final config = await AppConfig.forEnvironment(env: env);
+    baseUrl = config.baseUrl;
+    serverUrl = '$baseUrl/api';
+  }
 
   static ApiSingleton getInstance() {
     return ApiSingleton();

--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+
+class AppConfig {
+  final String baseUrl;
+  
+  AppConfig({required this.baseUrl});
+
+  static Future<AppConfig> forEnvironment({String env = 'dev'}) async {
+    final contents = await rootBundle.loadString(
+      'assets/config/$env.json',
+    );
+
+    final json = jsonDecode(contents);
+
+    return AppConfig(baseUrl: json['baseUrl']);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,8 @@ import 'dart:async';
 
 import 'package:connectivity/connectivity.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:mosquito_alert_app/api/api.dart';
-import 'package:mosquito_alert_app/app_config.dart';
 import 'package:mosquito_alert_app/pages/main/main_vc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:mosquito_alert_app/utils/Application.dart';
@@ -17,12 +15,7 @@ final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 void main({String env = 'dev'}) async {
   WidgetsFlutterBinding.ensureInitialized();
-  final config = await AppConfig.forEnvironment(env: env);
-
-  ApiSingleton.baseUrl = config.baseUrl;
-  ApiSingleton.serverUrl = '${config.baseUrl}/api';
-  print('base url: ${ApiSingleton.baseUrl}');  
-  print('server Url: ${ApiSingleton.serverUrl}');
+  await ApiSingleton.initialize(env);
 
   try {
     await Firebase.initializeApp();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,7 @@ import 'package:overlay_support/overlay_support.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
-void main({String env = 'dev'}) async {
+void main({String env = 'prod'}) async {
   WidgetsFlutterBinding.ensureInitialized();
   await ApiSingleton.initialize(env);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:connectivity/connectivity.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:mosquito_alert_app/api/api.dart';
+import 'package:mosquito_alert_app/app_config.dart';
 import 'package:mosquito_alert_app/pages/main/main_vc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:mosquito_alert_app/utils/Application.dart';
@@ -13,13 +15,21 @@ import 'package:overlay_support/overlay_support.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
-main() async {
+void main({String env = 'dev'}) async {
   WidgetsFlutterBinding.ensureInitialized();
+  final config = await AppConfig.forEnvironment(env: env);
+
+  ApiSingleton.baseUrl = config.baseUrl;
+  ApiSingleton.serverUrl = '${config.baseUrl}/api';
+  print('base url: ${ApiSingleton.baseUrl}');  
+  print('server Url: ${ApiSingleton.serverUrl}');
+
   try {
     await Firebase.initializeApp();
   } catch (err) {
     print('$err');
   }
+
   runApp(MyApp());
 }
 
@@ -31,8 +41,6 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
-
   late StreamSubscription<ConnectivityResult> subscription;
 
   MyLocalizationsDelegate _newLocaleDelegate = MyLocalizationsDelegate();
@@ -66,7 +74,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   @override
-  dispose() {
+  void dispose() {
     super.dispose();
     subscription.cancel();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,6 @@ void main({String env = 'dev'}) async {
   } catch (err) {
     print('$err');
   }
-
   runApp(MyApp());
 }
 

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,0 +1,5 @@
+import 'package:mosquito_alert_app/main.dart' as app;
+
+void main() {
+  app.main(env: 'dev');
+}

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -1,0 +1,5 @@
+import 'package:mosquito_alert_app/main.dart' as app;
+
+void main() {
+  app.main(env: 'prod');
+}

--- a/lib/pages/main/main_vc.dart
+++ b/lib/pages/main/main_vc.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-//import 'package:connectivity_widget/connectivity_widget.dart';
 import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
@@ -44,7 +43,7 @@ class _MainVCState extends State<MainVC> {
     loadingStream.add(true);
   }
 
-  initAuthStatus() async {
+  void initAuthStatus() async {
     if (Platform.isIOS) {
       await AppTrackingTransparency.requestTrackingAuthorization();
     }
@@ -58,12 +57,9 @@ class _MainVCState extends State<MainVC> {
 
   }
 
-  _getData() async {
+  void _getData() async {
     await UserManager.startFirstTime(context);
-    // dynamic user;
-    // if (Utils.userFetched) {
-    //   user = await UserManager.fetchUser();
-    // }
+
     userUuid = await UserManager.getUUID();
     UserManager.userScore = await ApiSingleton().getUserScores();
     await UserManager.setUserScores(UserManager.userScore);
@@ -84,7 +80,7 @@ class _MainVCState extends State<MainVC> {
     loadingStream.add(false);
   }
 
-  _bgTracking() async {
+  void _bgTracking() async {
     bool? trackingDisabled = await UserManager.getTracking();
     if (trackingDisabled == null || !trackingDisabled) {
       // 1.  Listen to events (See docs for all 12 available events).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ flutter:
     - assets/img/bottoms/
     - assets/language/
     - assets/html/
+    - assets/config/
 
   fonts:
     - family: Rubik


### PR DESCRIPTION
fixes #41 

## Description of changes
- To use different environment variables, dart requires the app to have different entry points (ie different files, main_prod.dart and main_dev.dart)
- This makes easier the future implementation of [Automate release of new versions to google play / apple store](#38) 

## How to use
- To start in prod: Run the file main_prod.dart, or in cmd: `flutter run -t lib/main_prod.dart`
- By default the app is started in dev mode. It can also be started in dev mode by running any of the following:
  - Run main.dart or main_dev.dart
  - Run `flutter run` or `flutter run -t lib/main_dev.dart`