### PR TITLE
phone_upload_time fields should be set on POST to API

### DIFF
--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -296,7 +296,7 @@ class ApiSingleton {
         body.addAll({'version_number': report.version_number});
         if (report.version_number == 0){
           body.addAll({'phone_upload_time': DateTime.now().toUtc().toIso8601String()});
-        }else if (report.phone_upload_time != null && report.phone_upload_time!.isNotEmpty){
+        } else if (report.phone_upload_time != null && report.phone_upload_time!.isNotEmpty){
           body.addAll({'phone_upload_time': report.phone_upload_time});
         }
       }

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -305,8 +305,6 @@ class ApiSingleton {
         body.addAll({'phone_upload_time': DateTime.now().toUtc().toIso8601String()});
       } else if (report.phone_upload_time != null && report.phone_upload_time!.isNotEmpty){
         body.addAll({'phone_upload_time': report.phone_upload_time});
-      } else {
-        body.addAll({'phone_upload_time': DateTime.now().toUtc().toIso8601String()});
       }
       if (report.creation_time != null && report.creation_time!.isNotEmpty) {
         body.addAll({'creation_time': report.creation_time});

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -294,18 +294,20 @@ class ApiSingleton {
       }
       if (report.version_number != null) {
         body.addAll({'version_number': report.version_number});
-        if (report.version_number == 0){
-          body.addAll({'phone_upload_time': DateTime.now().toUtc().toIso8601String()});
-        } else if (report.phone_upload_time != null && report.phone_upload_time!.isNotEmpty){
-          body.addAll({'phone_upload_time': report.phone_upload_time});
-        }
       }
       if (report.user != null && report.user!.isNotEmpty) {
         body.addAll({'user': report.user});
       }
       if (report.report_id != null && report.report_id!.isNotEmpty) {
         body.addAll({'report_id': report.report_id});
-      }      
+      }
+      if (report.version_number != null && report.version_number == 0){
+        body.addAll({'phone_upload_time': DateTime.now().toUtc().toIso8601String()});
+      } else if (report.phone_upload_time != null && report.phone_upload_time!.isNotEmpty){
+        body.addAll({'phone_upload_time': report.phone_upload_time});
+      } else {
+        body.addAll({'phone_upload_time': DateTime.now().toUtc().toIso8601String()});
+      }
       if (report.creation_time != null && report.creation_time!.isNotEmpty) {
         body.addAll({'creation_time': report.creation_time});
       }

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -295,17 +295,18 @@ class ApiSingleton {
       }
       if (report.version_number != null) {
         body.addAll({'version_number': report.version_number});
+        if (report.version_number == 0){
+          body.addAll({'phone_upload_time': DateTime.now().toUtc().toIso8601String()});
+        }else if (report.phone_upload_time != null && report.phone_upload_time!.isNotEmpty){
+          body.addAll({'phone_upload_time': report.phone_upload_time});
+        }
       }
       if (report.user != null && report.user!.isNotEmpty) {
         body.addAll({'user': report.user});
       }
       if (report.report_id != null && report.report_id!.isNotEmpty) {
         body.addAll({'report_id': report.report_id});
-      }
-      if (report.phone_upload_time != null &&
-          report.phone_upload_time!.isNotEmpty) {
-        body.addAll({'phone_upload_time': report.phone_upload_time});
-      }
+      }      
       if (report.creation_time != null && report.creation_time!.isNotEmpty) {
         body.addAll({'creation_time': report.creation_time});
       }

--- a/lib/utils/Utils.dart
+++ b/lib/utils/Utils.dart
@@ -155,13 +155,13 @@ class Utils {
     return false;
   }
 
-  static resetReport() {
+  static void resetReport() {
     report = null;
     session = null;
     reportsList = null;
   }
 
-  static setEditReport(Report editReport) {
+  static void setEditReport(Report editReport) {
     resetReport();
     report = editReport;
     report!.version_number = report!.version_number! + 1;
@@ -178,10 +178,9 @@ class Utils {
     }
   }
 
-  static addOtherReport(String type) {
+  static void addOtherReport(String type) {
     report!.version_time = DateTime.now().toUtc().toIso8601String();
     report!.creation_time = DateTime.now().toUtc().toIso8601String();
-    report!.phone_upload_time = DateTime.now().toUtc().toIso8601String();
 
     reportsList!.add(report);
     report = null;
@@ -198,7 +197,7 @@ class Utils {
     }
   }
 
-  static deleteLastReport() {
+  static void deleteLastReport() {
     report = null;
     report = Report.fromJson(reportsList!.last!.toJson());
     reportsList!.removeLast();
@@ -363,7 +362,6 @@ class Utils {
     } else {
       report!.version_time = DateTime.now().toUtc().toIso8601String();
       report!.creation_time = DateTime.now().toUtc().toIso8601String();
-      report!.phone_upload_time = DateTime.now().toUtc().toIso8601String();
       reportsList!.add(report);
       bool? isCreated;
       for (int i = 0; i < reportsList!.length; i++) {


### PR DESCRIPTION
fixes #39 

## Description of changes
- phone_upload_time only set on createReport of the api
- On createReport, set phone_upload_time to now() if version_number == 0, otherwise keep value (if not null)