### PR TITLE
Fix isBgTrackingEnabled not initialized

### DIFF
--- a/lib/pages/settings_pages/settings_page.dart
+++ b/lib/pages/settings_pages/settings_page.dart
@@ -27,7 +27,7 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  late bool isBgTrackingEnabled;
+  bool isBgTrackingEnabled = false;
   String? hashtag;
   var packageInfo;
 


### PR DESCRIPTION
Fix exception on output console when entering settings page
![image](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/751ca84b-c172-4a5d-ad30-91ae6f3f5999)

Set initially as `false` until the async method `initializeBgTracking()` finishes