### PR TITLE
Display public map in a webview

### DIFF
--- a/lib/pages/main/main_vc.dart
+++ b/lib/pages/main/main_vc.dart
@@ -15,6 +15,7 @@ import 'package:mosquito_alert_app/pages/info_pages/info_page.dart';
 import 'package:mosquito_alert_app/pages/main/components/custom_card_widget.dart';
 import 'package:mosquito_alert_app/pages/my_reports_pages/my_reports_page.dart';
 import 'package:mosquito_alert_app/pages/notification_pages/notifications_page.dart';
+import 'package:mosquito_alert_app/pages/public_map.dart';
 import 'package:mosquito_alert_app/pages/settings_pages/campaign_tutorial_page.dart';
 import 'package:mosquito_alert_app/pages/settings_pages/settings_page.dart';
 import 'package:mosquito_alert_app/utils/MyLocalizations.dart';
@@ -276,7 +277,9 @@ class _MainVCState extends State<MainVC> {
                                       GestureDetector(
                                         onTap: () {
                                           loadingStream.add(true);
-                                          _createBiteReport();
+                                          //_createBiteReport();
+                                          // TODO: Remove this from the final PR, it's only for debugging
+                                          Navigator.of(context).push(MaterialPageRoute(builder: (context) => PublicMap()));
                                         },
                                         child: Container(
                                           width: MediaQuery.of(context)
@@ -290,8 +293,7 @@ class _MainVCState extends State<MainVC> {
                                           child: CustomCard(
                                             img:
                                                 'assets/img/ic_bite_report.png',
-                                            title: MyLocalizations.of(
-                                                context, 'report_biting_txt'),
+                                            title: 'DEBUG PUBLIC MAP'//MyLocalizations.of(context, 'report_biting_txt'),
                                           ),
                                         ),
                                       ),

--- a/lib/pages/public_map.dart
+++ b/lib/pages/public_map.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:mosquito_alert_app/utils/Utils.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class PublicMap extends StatefulWidget {
+  @override
+  _PublicMapState createState() => _PublicMapState();
+}
+
+class _PublicMapState extends State<PublicMap> {
+  late WebViewController _controller;
+  StreamController<bool> loadingStream = StreamController<bool>.broadcast();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(const Color(0x00000000))
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageStarted: (String url) {
+          },
+          onPageFinished: (String url) {
+            loadingStream.add(false);
+          },
+          onWebResourceError: (WebResourceError error) {
+            print(error);
+          },
+        ),
+      );
+
+      _controller.loadRequest(Uri.parse('https://map.mosquitoalert.com'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Mosquito Alert Map'),
+        backgroundColor: Colors.white,
+      ),
+      body: SafeArea(
+        child: Stack(
+          children: [
+            Builder(builder: (BuildContext context) {
+              return WebViewWidget(
+                controller: _controller,
+              );
+            }),
+            StreamBuilder<bool>(
+              stream: loadingStream.stream,
+              initialData: true,
+              builder: (BuildContext context, AsyncSnapshot<bool> snapLoading) {
+                if (snapLoading.data != true) {
+                  return Container();
+                }
+
+                return Container(
+                  child: Center(
+                    child: Utils.loading(true),
+                  ),
+                );
+              }
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
fixes #52

- This PR should be merged after #138 because the map is accessed through the drawer 

![image](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/2a6be1da-e258-400f-9e8c-8582a95a3076)
