### PR TITLE
Fix null error when exiting camera without selecting a photo

### DIFF
--- a/lib/pages/forms_pages/components/add_photo_button_widget.dart
+++ b/lib/pages/forms_pages/components/add_photo_button_widget.dart
@@ -182,6 +182,10 @@ class _AddPhotoButtonState extends State<AddPhotoButton> {
        builder: (context) => const WhatsappCamera(multiple: false,)),
     );
 
+    if(files == null){
+      return;
+    }
+
     var file = files[0];
     Utils.saveImgPath(file);
     setState(() {

--- a/lib/pages/forms_pages/components/add_photo_button_widget.dart
+++ b/lib/pages/forms_pages/components/add_photo_button_widget.dart
@@ -176,7 +176,7 @@ class _AddPhotoButtonState extends State<AddPhotoButton> {
   }
 
   Future<void> getImageWhatsapp() async{
-    List<File> files = await Navigator.push(
+    List<File>? files = await Navigator.push(
      context,
      MaterialPageRoute(
        builder: (context) => const WhatsappCamera(multiple: false,)),


### PR DESCRIPTION
| First Header  | Second Header |
| ------------- | ------------- |
| ![image](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/d557509c-59ae-4db6-8d0a-04df4bbe9c74) | ![image](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/8a68ebad-ac2f-4192-b27e-be1cdc80677c) |