### PR TITLE
Move gallery button to bottom right

### DIFF
--- a/lib/pages/forms_pages/components/whatsapp_camera.dart/camera_whatsapp.dart
+++ b/lib/pages/forms_pages/components/whatsapp_camera.dart/camera_whatsapp.dart
@@ -206,7 +206,17 @@ class _WhatsappCameraState extends State<WhatsappCamera>
                   onPressed: (() => Navigator.pop(context)),
                   icon: const Icon(Icons.close),
                 ),
-                IconButton(
+              ],
+            ),
+          ),
+          Align(
+            alignment: Alignment.bottomRight,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 32, right: 64),
+              child: CircleAvatar(
+                radius: 20,
+                backgroundColor: Colors.black.withOpacity(0.6),
+                child: IconButton(
                   color: Colors.white,
                   onPressed: () async {
                     await controller.openGallery().then((value) {
@@ -217,7 +227,7 @@ class _WhatsappCameraState extends State<WhatsappCamera>
                   },
                   icon: const Icon(Icons.image),
                 ),
-              ],
+              ),
             ),
           ),
           Positioned(


### PR DESCRIPTION
fixes #17 
> could the camera layout be adjusted to place the gallery button next to the shutter button (on its right) instead of in the top-right corner?

![image](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/2c1c4ea9-9a8c-4cab-8c14-fe06ba40816e)
