### PR TITLE
Fix random crash when selecting a recent image from whatsapp camera (happened 10-20% of the time)

### DIFF
--- a/lib/pages/forms_pages/components/whatsapp_camera.dart/camera_whatsapp.dart
+++ b/lib/pages/forms_pages/components/whatsapp_camera.dart/camera_whatsapp.dart
@@ -45,7 +45,7 @@ class _WhatsAppCameraController extends ChangeNotifier {
 
   _timer() {
     Timer.periodic(const Duration(seconds: 2), (t) async {
-      Permission.camera.isGranted.then((value) {
+      await Permission.camera.isGranted.then((value) {
         if (value) {
           getPhotosToGallery();
           t.cancel();
@@ -250,7 +250,7 @@ class _WhatsappCameraState extends State<WhatsappCamera>
                               itemBuilder: (context, index) {
                                 return InkWell(
                                   onTap: () async {
-                                    controller
+                                    await controller
                                         .selectImage(controller.images[index])
                                         .then((value) {
                                       Navigator.pop(
@@ -282,7 +282,8 @@ class _WhatsappCameraState extends State<WhatsappCamera>
                           ),
                         ],
                       );
-                    }),
+                    }
+                  ),
               ),
             ),
           ),
@@ -489,7 +490,7 @@ class _ImageItem extends StatelessWidget {
               color: Colors.white,
               icon: const Icon(Icons.zoom_out_map_outlined),
               onPressed: () async {
-                image.getFile().then((value) {
+                await image.getFile().then((value) {
                   Navigator.of(context).push(MaterialPageRoute(
                     builder: (context) {
                       return Hero(


### PR DESCRIPTION
I believe it could be due to not awaiting for future objects. After adding those missing `await`, I could not reproduce the issue anymore, so I think it's solved

```
W/velab.tigatrap( 5657): Long monitor contention with owner main (5657) at void android.hardware.camera2.impl.CameraDeviceImpl.close()(CameraDeviceImpl.java:1433) waiters=0 in void android.hardware.camera2.impl.CameraDeviceImpl$CameraDeviceCallbacks.onCaptureStarted(android.hardware.camera2.impl.CaptureResultExtras, long) for 184ms
E/AndroidRuntime( 5657): FATAL EXCEPTION: CameraBackground
E/AndroidRuntime( 5657): Process: ceab.movelab.tigatrapp, PID: 5657
E/AndroidRuntime( 5657): java.lang.NullPointerException: Attempt to invoke virtual method 'void android.hardware.camera2.CameraCaptureSession.close()' on a null object reference
E/AndroidRuntime( 5657): 	at io.flutter.plugins.camera.Camera.closeCaptureSession(Camera.java:1299)
E/AndroidRuntime( 5657): 	at io.flutter.plugins.camera.Camera$1.onClosed(Camera.java:414)
E/AndroidRuntime( 5657): 	at android.hardware.camera2.impl.CameraDeviceImpl$5.run(CameraDeviceImpl.java:237)
E/AndroidRuntime( 5657): 	at android.os.Handler.handleCallback(Handler.java:938)
E/AndroidRuntime( 5657): 	at android.os.Handler.dispatchMessage(Handler.java:99)
E/AndroidRuntime( 5657): 	at android.os.Looper.loopOnce(Looper.java:201)
E/AndroidRuntime( 5657): 	at android.os.Looper.loop(Looper.java:288)
E/AndroidRuntime( 5657): 	at android.os.HandlerThread.run(HandlerThread.java:67)
I/Process ( 5657): Sending signal. PID: 5657 SIG: 9
```

![select_from_recent](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/5255a2bd-34d3-44e6-8f78-7d1cd605345f)
