### PR TITLE
Fix bug where it's possible to skip pages on adult report after at least a photo has been attached

### DIFF
--- a/lib/pages/forms_pages/adult_report_page.dart
+++ b/lib/pages/forms_pages/adult_report_page.dart
@@ -259,7 +259,7 @@ class _AdultReportPageState extends State<AdultReportPage> {
                   children: _formsRepot!,
                 ),
                 index! < 1.0
-                  ? continueButtonPhotos(index)
+                  ? continueButtonPhotos()
                   : index != _formsRepot!.length.toDouble() - 1
                     ? SafeArea(
                       child: Align(
@@ -336,7 +336,11 @@ class _AdultReportPageState extends State<AdultReportPage> {
     });
   }
 
-  Widget continueButtonPhotos(double? index){
+  Widget continueButtonPhotos(){
+    if(!_atLeastOnePhotoAttached){
+      return Container();
+    }
+
     return Container(
       width: double.infinity,
       height: 54,

--- a/lib/pages/forms_pages/adult_report_page.dart
+++ b/lib/pages/forms_pages/adult_report_page.dart
@@ -259,7 +259,7 @@ class _AdultReportPageState extends State<AdultReportPage> {
                   children: _formsRepot!,
                 ),
                 index! < 1.0
-                  ? continueButton(index)
+                  ? continueButtonPhotos(index)
                   : index != _formsRepot!.length.toDouble() - 1
                     ? SafeArea(
                       child: Align(
@@ -336,13 +336,20 @@ class _AdultReportPageState extends State<AdultReportPage> {
     });
   }
 
-  Widget continueButton(double? index){
-    if (index == null || index == 0.0){
-      if (!_atLeastOnePhotoAttached){
-        return Container();
-      }
-    }
+  Widget continueButtonPhotos(double? index){
+    return Container(
+      width: double.infinity,
+      height: 54,
+      margin: EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+      child: Style.button(
+        MyLocalizations.of(context, 'continue_txt'), () {
+          goNextPage();
+        }
+      )
+    );
+  }
 
+  Widget continueButton(double? index){
     return Container(
       width: double.infinity,
       height: 54,


### PR DESCRIPTION
Fix bug where it's possible to skip pages on adult pages after at least 1 photo has been attached

| Before | After |
| ------------- | ------------- |
| ![bug_skip_adult](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/dc4b669d-8183-4aad-a807-4b9a6a8122e2)  | ![fix_skip_adult](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/679c33e3-fcc9-4eba-a790-9ada07ec5e11) |