### PR TITLE
Directly open camera instead of showing "Attach a photo" page

### DIFF
--- a/lib/pages/forms_pages/components/add_photo_button_widget.dart
+++ b/lib/pages/forms_pages/components/add_photo_button_widget.dart
@@ -30,7 +30,14 @@ class _AddPhotoButtonState extends State<AddPhotoButton> {
   void initState() {
     _permissionsPath();
     super.initState();
-    _initImages();
+    initializePhotos();
+  }
+
+  Future<void> initializePhotos() async {
+    await _initImages();
+    if (images.isEmpty){
+      await getImageWhatsapp();
+    }    
   }
 
   Future<void> _permissionsPath() async {


### PR DESCRIPTION
fixes #17 

Also avoid opening the camera if there is already at least an image attached, which would be triggered if the users goes back during the report loop

| Adult | Breding site |
| ------------- | ------------- |
| ![directly_open_camera_adult](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/7fb23be0-c69e-44f3-89be-9257bb55e9fa) | ![directly_open_camera_site](https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/assets/157690872/4e82c9b3-2b23-4001-9dbe-78c623fa645c) |