### PR TITLE
Update min sdk to 2.15.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 version: 2.3.0+1732
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
On the camera whatsapp there is this warning that is gone when I update the minimum SDK to 2.15.0
![api_sdk_available_2 15 0](https://github.com/user-attachments/assets/04c9cacd-b6d0-47cf-bf9c-bf6a8390984b)
