### PR TITLE
Auto-tagging - Avoid double hashtag

### DIFF
--- a/lib/pages/settings_pages/components/hashtag.dart
+++ b/lib/pages/settings_pages/components/hashtag.dart
@@ -142,6 +142,10 @@ class _StringMultilineTagsState extends State<StringMultilineTags> {
                     ),
                     onChanged: inputFieldValues.onTagChanged,
                     onSubmitted: (String newTag){
+                      if (newTag.startsWith('#')) {
+                        newTag = newTag.substring(1);
+                      }
+
                       if (!hashtags.contains(newTag)) {
                         inputFieldValues.onTagSubmitted(newTag);
                         hashtags.add(newTag);

--- a/lib/pages/settings_pages/components/hashtag.dart
+++ b/lib/pages/settings_pages/components/hashtag.dart
@@ -142,9 +142,7 @@ class _StringMultilineTagsState extends State<StringMultilineTags> {
                     ),
                     onChanged: inputFieldValues.onTagChanged,
                     onSubmitted: (String newTag){
-                      if (newTag.startsWith('#')) {
-                        newTag = newTag.substring(1);
-                      }
+                      newTag = newTag.replaceAll('#', '');
 
                       if (!hashtags.contains(newTag)) {
                         inputFieldValues.onTagSubmitted(newTag);


### PR DESCRIPTION
fixes #190 -> Users until now (schools) have been told that they should use '#' as a prefix, and now doing so appears two hashtags. Can this be avoided?

![avoid_double_hashtag](https://github.com/user-attachments/assets/467b6675-ceb2-48de-95d6-3eb7d9afc006)
