### PR TITLE
Auto-tagging - Cancel color set to white

### DIFF
--- a/lib/pages/settings_pages/components/hashtag.dart
+++ b/lib/pages/settings_pages/components/hashtag.dart
@@ -122,8 +122,7 @@ class _StringMultilineTagsState extends State<StringMultilineTags> {
                                         child: const Icon(
                                           Icons.cancel,
                                           size: 14.0,
-                                          color: Color.fromARGB(
-                                              255, 233, 233, 233),
+                                          color: Colors.white,
                                         ),
                                         onTap: () {
                                           inputFieldValues.onTagRemoved(tag);


### PR DESCRIPTION
fixes #190 -> The button with the 'X' is gray, but it should be white (always the same color as text).

![image](https://github.com/user-attachments/assets/c8d21a5f-5b04-4ef2-b6da-0ead22eabb86)
