### PR TITLE
Auto-tagging - Keep extension tile open

### DIFF
--- a/lib/pages/settings_pages/settings_page.dart
+++ b/lib/pages/settings_pages/settings_page.dart
@@ -23,7 +23,8 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   bool isBgTrackingEnabled = false;
   var packageInfo;
-  int numTagsAdded = 0;
+  late int? numTagsAdded;
+  bool isLoading = true;
 
   final languageCodes = [
     Language('bg_BG', 'Bulgarian'),
@@ -75,6 +76,7 @@ class _SettingsPageState extends State<SettingsPage> {
     var hashtags = await UserManager.getHashtags();
     setState(() {
       numTagsAdded = hashtags?.length ?? 0;
+      isLoading = false;
     });
   }
 
@@ -93,7 +95,14 @@ class _SettingsPageState extends State<SettingsPage> {
       body: SingleChildScrollView(
         child: Container(
           margin: EdgeInsets.all(15),
-          child:
+          child: isLoading ? 
+            Container(
+                height: MediaQuery.sizeOf(context).height * 0.8,
+                child: Center(
+                  child: CircularProgressIndicator()
+                ),
+            )            
+          :
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
@@ -150,13 +159,14 @@ class _SettingsPageState extends State<SettingsPage> {
                 children: [
                   Expanded(
                     child: ExpansionTile(
+                      initiallyExpanded: numTagsAdded! > 0,
                       title: Row(
                         children: [
                             Text(
                               MyLocalizations.of(context, 'auto_tagging_settings_title'),
                             ),
                             Spacer(flex: 1),
-                          if (numTagsAdded > 0)
+                          if (numTagsAdded! > 0)
                             Container(
                               margin: EdgeInsets.only(left: 8.0),
                               padding: EdgeInsets.all(4.0),


### PR DESCRIPTION
fixes #190

| If there's >= 1 tag, init unfolded | When deleting tag, it's still unfolded | When pressing enter, it's still unfolded |
| ------------- | ------------- | ------------- |
| ![init_unfolded](https://github.com/user-attachments/assets/94e04ba6-7304-44b5-b679-ea43e97bf7ef) | ![delete_does_not_close](https://github.com/user-attachments/assets/ab2e4e47-4ff3-4be1-8cf9-8771b113a271) | ![pressing_enter_keeps_unfolded](https://github.com/user-attachments/assets/1ab7890f-c763-4a4f-827f-649745085ce0) |
