### PR TITLE
Auto-tagging: handle backspace

### DIFF
--- a/lib/pages/settings_pages/components/hashtag.dart
+++ b/lib/pages/settings_pages/components/hashtag.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mosquito_alert_app/utils/MyLocalizations.dart';
 import 'package:mosquito_alert_app/utils/UserManager.dart';
 import 'package:textfield_tags/textfield_tags.dart';
@@ -17,6 +18,7 @@ class _StringMultilineTagsState extends State<StringMultilineTags> {
   late StringTagController _stringTagController;
   late List<String> hashtags;
   bool isLoading = true;
+  String currentWord = '';
 
   void getHashtags() async {
     hashtags = await UserManager.getHashtags() ?? [];
@@ -46,115 +48,124 @@ class _StringMultilineTagsState extends State<StringMultilineTags> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: Column(
-        children: [
-          if (isLoading)
-            CircularProgressIndicator()
-          else
-            TextFieldTags<String>(
-              textfieldTagsController: _stringTagController,
-              initialTags: hashtags,
-              textSeparators: const [' ', ','],
-              letterCase: LetterCase.normal,
-              inputFieldBuilder: (context, inputFieldValues) {
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 10.0),
-                  child: TextField(
-                    onTap: () {
-                      _stringTagController.getFocusNode?.requestFocus();
-                    },
-                    controller: inputFieldValues.textEditingController,
-                    focusNode: inputFieldValues.focusNode,
-                    decoration: InputDecoration(
-                      isDense: true,
-                      border: const OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: Color.fromARGB(255, 74, 137, 92),
-                          width: 3.0,
-                        ),
-                      ),
-                      focusedBorder: const OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: Colors.grey,
-                          width: 3.0,
-                        ),
-                      ),
-                      hintText: inputFieldValues.tags.isNotEmpty ? '' : MyLocalizations.of(context, 'auto_tagging_settings_placeholder'),
-                      errorText: inputFieldValues.error,
-                      prefixIconConstraints: BoxConstraints(maxWidth: _distanceToField * 0.8),
-                      prefixIcon: inputFieldValues.tags.isEmpty ? null :
-                        SingleChildScrollView(
-                          controller: inputFieldValues.tagScrollController,
-                          scrollDirection: Axis.vertical,
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                              top: 8,
-                              bottom: 8,
-                              left: 8,
-                            ),
-                            child: Wrap(
-                              runSpacing: 4.0,
-                              spacing: 4.0,
-                              children: inputFieldValues.tags.map((String tag) {
-                                return Container(
-                                  decoration: const BoxDecoration(
-                                    borderRadius: BorderRadius.all(
-                                      Radius.circular(20.0),
-                                    ),
-                                    color: Colors.orange,
-                                  ),
-                                  margin: const EdgeInsets.symmetric(horizontal: 5.0),
-                                  padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
-                                  child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.start,
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      InkWell(
-                                        child: Text(
-                                          '#$tag',
-                                          style: const TextStyle(color: Colors.white),
-                                        ),
-                                      ),
-                                      const SizedBox(width: 4.0),
-                                      InkWell(
-                                        child: const Icon(
-                                          Icons.cancel,
-                                          size: 14.0,
-                                          color: Colors.white,
-                                        ),
-                                        onTap: () {
-                                          inputFieldValues.onTagRemoved(tag);
-                                          hashtags.remove(tag);
-                                          UserManager.setHashtags(hashtags);
-                                          widget.updateTagsNum(hashtags.length);
-                                        },
-                                      )
-                                    ],
-                                  ),
-                                );
-                              }).toList()
-                            ),
+    return KeyboardListener(
+      focusNode: FocusNode(),
+      onKeyEvent: (value) {
+        if (value.logicalKey.keyLabel == 'Backspace' && value is KeyDownEvent && currentWord == ''){
+          onBackspace();
+        }
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        child: Column(
+          children: [
+            if (isLoading)
+              CircularProgressIndicator()
+            else
+              TextFieldTags<String>(
+                textfieldTagsController: _stringTagController,
+                initialTags: hashtags,
+                textSeparators: const [' ', ','],
+                letterCase: LetterCase.normal,
+                inputFieldBuilder: (context, inputFieldValues) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 10.0),
+                    child: TextField(
+                      onTap: () {
+                        _stringTagController.getFocusNode?.requestFocus();
+                      },
+                      controller: inputFieldValues.textEditingController,
+                      focusNode: inputFieldValues.focusNode,
+                      decoration: InputDecoration(
+                        isDense: true,
+                        border: const OutlineInputBorder(
+                          borderSide: BorderSide(
+                            color: Color.fromARGB(255, 74, 137, 92),
+                            width: 3.0,
                           ),
-                        )
-                    ),
-                    onChanged: (String change){
-                      if (change.endsWith(' ')){
-                        // Space was pressed                        
-                        addNewHashtag(change, inputFieldValues);
+                        ),
+                        focusedBorder: const OutlineInputBorder(
+                          borderSide: BorderSide(
+                            color: Colors.grey,
+                            width: 3.0,
+                          ),
+                        ),
+                        hintText: inputFieldValues.tags.isNotEmpty ? '' : MyLocalizations.of(context, 'auto_tagging_settings_placeholder'),
+                        errorText: inputFieldValues.error,
+                        prefixIconConstraints: BoxConstraints(maxWidth: _distanceToField * 0.8),
+                        prefixIcon: inputFieldValues.tags.isEmpty ? null :
+                          SingleChildScrollView(
+                            controller: inputFieldValues.tagScrollController,
+                            scrollDirection: Axis.vertical,
+                            child: Padding(
+                              padding: const EdgeInsets.only(
+                                top: 8,
+                                bottom: 8,
+                                left: 8,
+                              ),
+                              child: Wrap(
+                                runSpacing: 4.0,
+                                spacing: 4.0,
+                                children: inputFieldValues.tags.map((String tag) {
+                                  return Container(
+                                    decoration: const BoxDecoration(
+                                      borderRadius: BorderRadius.all(
+                                        Radius.circular(20.0),
+                                      ),
+                                      color: Colors.orange,
+                                    ),
+                                    margin: const EdgeInsets.symmetric(horizontal: 5.0),
+                                    padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
+                                    child: Row(
+                                      mainAxisAlignment: MainAxisAlignment.start,
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        InkWell(
+                                          child: Text(
+                                            '#$tag',
+                                            style: const TextStyle(color: Colors.white),
+                                          ),
+                                        ),
+                                        const SizedBox(width: 4.0),
+                                        InkWell(
+                                          child: const Icon(
+                                            Icons.cancel,
+                                            size: 14.0,
+                                            color: Colors.white,
+                                          ),
+                                          onTap: () {
+                                            inputFieldValues.onTagRemoved(tag);
+                                            hashtags.remove(tag);
+                                            UserManager.setHashtags(hashtags);
+                                            widget.updateTagsNum(hashtags.length);
+                                          },
+                                        )
+                                      ],
+                                    ),
+                                  );
+                                }).toList()
+                              ),
+                            ),
+                          )
+                      ),
+                      onChanged: (String change){
+                        currentWord = change;
+                        if (change.endsWith(' ')){
+                          // Space was pressed                        
+                          addNewHashtag(change, inputFieldValues);
+                        }
+                        inputFieldValues.onTagChanged(change);
+                      },
+                      onSubmitted: (String newTag){
+                        addNewHashtag(newTag, inputFieldValues);
                       }
-                      inputFieldValues.onTagChanged(change);
-                    },
-                    onSubmitted: (String newTag){
-                      addNewHashtag(newTag, inputFieldValues);
-                    }
-                  ),
-                );
-              },
-            ),
-        ],
-      ),
+                    ),
+                  );
+                },
+              ),
+          ],
+        ),
+      )
     );
   }
 
@@ -166,6 +177,16 @@ class _StringMultilineTagsState extends State<StringMultilineTags> {
       hashtags.add(newTag);
       UserManager.setHashtags(hashtags);
       widget.updateTagsNum(hashtags.length);
+      currentWord = '';
     }
+  }
+
+  void onBackspace(){
+    // Delete last hashtag
+    if (hashtags.isEmpty) { return; }
+
+    hashtags.removeLast();
+    UserManager.setHashtags(hashtags);
+    widget.updateTagsNum(hashtags.length);
   }
 }


### PR DESCRIPTION
fixes #195  -> It is expected that tags can be deleted using the 'delete' key on the keyboard

### Description of changes
- Wrap the StringMultilineTag in a KeyboardListener to check when 'Backspace' is pressed
- Create 'currentWord' to only remove the last hashtag when it's an empty string (Otherwise it would remove the hashtag every time even if you are in the middle of creating a new hashtag, and press backspace)

![handle_backspace_2](https://github.com/user-attachments/assets/3f175337-1c85-4a13-b0ec-b1054acd6044)
