### PR TITLE
Enable -Xlint:deprecation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,12 @@ allprojects {
             }
         }
     }
+
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:deprecation"
+        }
+    } 
 }
 
 rootProject.buildDir = '../build'


### PR DESCRIPTION
Increase warning details in the log when running the app locally

Before:
![image](https://github.com/user-attachments/assets/93c98d8b-6ace-4ee7-a13a-df7b3cec4ae8)

After:
```
\AppData\Local\Pub\Cache\hosted\pub.dev\firebase_messaging-15.2.0\android\src\main\java\io\flutter\n] getTo() in RemoteMessage has been deprecated
      messageMap.put(KEY_TO, remoteMessage.getTo());
                                          ^
2 warnings
```