### PR TITLE
workmanager: add explanation of why it's using a custom ref

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,8 @@ dependencies:
   flutter_html: ^3.0.0-beta.2
   webview_flutter: ^4.5.0
   workmanager:
+    # The reason to have a custom ref is because the latest published version
+    # was not working for iOS, and a custom unreleased commit was solving it.
     git:
         url: https://github.com/fluttercommunity/flutter_workmanager.git
         ref: b783000


### PR DESCRIPTION
Since having custom dependency versions is usually a bad practice, I think it's a good idea to add a comment explaining why we did that, so that in the future we don't revert it so easily, breaking something for iOS