### PR TITLE
Removed duplicate workmanager registration message

### DIFF
--- a/android/app/src/main/kotlin/com/example/mosquito_alert_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mosquito_alert_app/MainActivity.kt
@@ -1,13 +1,6 @@
 package com.example.mosquito_alert_app
 
-import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.engine.FlutterEngine
-import dev.fluttercommunity.workmanager.WorkmanagerPlugin
 
 class MainActivity: FlutterActivity() {
-    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-        super.configureFlutterEngine(flutterEngine)
-        flutterEngine.plugins.add(WorkmanagerPlugin())
-    }
 }


### PR DESCRIPTION
This was the warning message being shown:
```
W/FlutterEngineCxnRegstry(10593): Attempted to register plugin (dev.fluttercommunity.workmanager.WorkmanagerPlugin@1244eeb) but it was already registered with this FlutterEngine (io.flutter.embedding.engine.FlutterEngine@1436448).
```

Introduced here: https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/commit/72b6c434c0eabb85da832ad7099ca47205cdd1b3