### PR TITLE
Updated firebase_messaging to 15.2.4

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "27899c95f9e7ec06c8310e6e0eac967707714b9f1450c4a58fa00ca011a4a8ae"
+      sha256: "7fd72d77a7487c26faab1d274af23fb008763ddc10800261abbfb2c067f183d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.49"
+    version: "1.3.53"
   _macros:
     dependency: transitive
     description: dart
@@ -362,26 +362,26 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "48a8a59197c1c5174060ba9aa1e0036e9b5a0d28a0cc22d19c1fcabc67fafe3c"
+      sha256: "5fc345c6341f9dc69fd0ffcbf508c784fd6d1b9e9f249587f30434dd8b6aa281"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.2.4"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "9770a8e91f54296829dcaa61ce9b7c2f9ae9abbf99976dd3103a60470d5264dd"
+      sha256: a935924cf40925985c8049df4968b1dde5c704f570f3ce380b31d3de6990dd94
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "4.6.4"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "329ca4ef45ec616abe6f1d5e58feed0934a50840a65aa327052354ad3c64ed77"
+      sha256: fafebf6a1921931334f3f10edb5037a5712288efdd022881e2d093e5654a2fd4
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.0"
+    version: "3.10.4"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   dio: ^5.3.3
   flutter_image_compress: ^2.3.0
   flutter_markdown: ^0.7.4+3
-  firebase_messaging: ^15.2.0
+  firebase_messaging: ^15.2.4
   firebase_core: ^3.12.1
   auto_size_text: ^3.0.0
   file_picker: ^8.0.3


### PR DESCRIPTION
See: https://github.com/firebase/flutterfire/pull/16995

Solving this message
```
getTo() in RemoteMessage has been deprecated
    if (remoteMessage.getTo() != null) {
                     ^
/home/runner/.pub-cache/hosted/pub.dev/firebase_messaging-15.2.0/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java:51: warning: [deprecation] getTo() in RemoteMessage has been deprecated
      messageMap.put(KEY_TO, remoteMessage.getTo());
```