### PR TITLE
Settings page: ‘Auto-tagging’ text should be the same size as other title

### DIFF
--- a/lib/pages/settings_pages/settings_page.dart
+++ b/lib/pages/settings_pages/settings_page.dart
@@ -168,7 +168,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       initiallyExpanded: numTagsAdded! > 0,
                       title: Row(
                         children: [
-                            Text(
+                            Style.body(
                               MyLocalizations.of(context, 'auto_tagging_settings_title'),
                             ),
                             Spacer(flex: 1),


### PR DESCRIPTION
The other titles are using Style.body
![image](https://github.com/user-attachments/assets/ff1ffc38-ab97-4ff6-9da0-b7d825835be0)
