### PR TITLE
Replace deprecated 'withOpacity'

### DIFF
--- a/lib/pages/forms_pages/components/add_other_report_form.dart
+++ b/lib/pages/forms_pages/components/add_other_report_form.dart
@@ -50,7 +50,7 @@ class _AddOtherReportPageState extends State<AddOtherReportPage> {
                     percent: snapshot.data!,
                     animateFromLastPercent: true,
                     animation: true,
-                    backgroundColor: Colors.grey.withOpacity(0.3),
+                    backgroundColor: Colors.grey.withValues(alpha: 0.3),
                     progressColor: Style.colorPrimary,
                   );
                 },

--- a/lib/pages/forms_pages/components/biting_form.dart
+++ b/lib/pages/forms_pages/components/biting_form.dart
@@ -276,7 +276,7 @@ class _BitingFormState extends State<BitingForm> {
                                     }
                                   : null,
                               child: Container(
-                                color: Colors.blue.withOpacity(0.0),
+                                color: Colors.blue..withValues(alpha: 0.0),
                                 height: mediaQuery.height * 0.1,
                                 width: mediaQuery.width * 0.18,
                               ),

--- a/lib/pages/forms_pages/components/whatsapp_camera.dart/camera_whatsapp.dart
+++ b/lib/pages/forms_pages/components/whatsapp_camera.dart/camera_whatsapp.dart
@@ -237,7 +237,7 @@ class _WhatsappCameraState extends State<WhatsappCamera>
               padding: const EdgeInsets.only(bottom: 32, right: 64),
               child: CircleAvatar(
                 radius: 20,
-                backgroundColor: Colors.black.withOpacity(0.6),
+                backgroundColor: Colors.black..withValues(alpha: 0.6),
                 child: IconButton(
                   color: Colors.white,
                   onPressed: () async {
@@ -497,7 +497,7 @@ class _ImageItem extends StatelessWidget {
           ),
           if (selected)
             Container(
-              color: Colors.grey.withOpacity(.3),
+              color: Colors.grey.withValues(alpha: 0.3),
               child: Center(
                 child: Stack(
                   children: [

--- a/lib/pages/main/drawer_and_header.dart
+++ b/lib/pages/main/drawer_and_header.dart
@@ -256,7 +256,7 @@ class _MainVCState extends State<MainVC> {
               Text(
                 'ID: ',
                 style: TextStyle(
-                  color: Colors.black.withOpacity(0.7),
+                  color: Colors.black.withValues(alpha: 0.7),
                   fontSize: 8,
                 ),
               ),

--- a/lib/pages/settings_pages/campaign_tutorial_page.dart
+++ b/lib/pages/settings_pages/campaign_tutorial_page.dart
@@ -59,10 +59,10 @@ class _CampaignTutorialPageState extends State<CampaignTutorialPage> {
         renderDoneBtn: renderDoneBtn(),
         onDonePress: onDonePress,
         doneButtonStyle: ButtonStyle(
-            backgroundColor:
-                WidgetStateProperty.all(Style.colorPrimary.withOpacity(0.2)),
+            backgroundColor: WidgetStateProperty.all(
+                Style.colorPrimary.withValues(alpha: 0.2)),
             overlayColor: WidgetStateProperty.all(Style.colorPrimary)),
-        colorDot: Style.colorPrimary.withOpacity(0.4),
+        colorDot: Style.colorPrimary.withValues(alpha: 0.4),
         sizeDot: 6.0,
         colorActiveDot: Style.colorPrimary,
         listCustomTabs: renderListCustomTabs(),

--- a/lib/pages/settings_pages/components/settings_menu_widget.dart
+++ b/lib/pages/settings_pages/components/settings_menu_widget.dart
@@ -13,7 +13,7 @@ class SettingsMenuWidget extends StatelessWidget {
       decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(5),
           color: Colors.white,
-          border: Border.all(color: Colors.black.withOpacity(0.1))),
+          border: Border.all(color: Colors.black.withValues(alpha: 0.1))),
       child: ListTile(
         onTap: () {
           onTap();

--- a/lib/pages/settings_pages/gallery_page.dart
+++ b/lib/pages/settings_pages/gallery_page.dart
@@ -157,10 +157,10 @@ class _GalleryPageState extends State<GalleryPage> {
         renderDoneBtn: renderDoneBtn(),
         onDonePress: onDonePress,
         doneButtonStyle: ButtonStyle(
-            backgroundColor:
-                WidgetStateProperty.all(Style.colorPrimary.withOpacity(0.2)),
+            backgroundColor: WidgetStateProperty.all(
+                Style.colorPrimary.withValues(alpha: 0.2)),
             overlayColor: WidgetStateProperty.all(Style.colorPrimary)),
-        colorDot: Style.colorPrimary.withOpacity(0.4),
+        colorDot: Style.colorPrimary.withValues(alpha: 0.4),
         sizeDot: 6.0,
         colorActiveDot: Style.colorPrimary,
         listCustomTabs: renderListCustomTabs(),

--- a/lib/pages/settings_pages/settings_page.dart
+++ b/lib/pages/settings_pages/settings_page.dart
@@ -130,7 +130,7 @@ class _SettingsPageState extends State<SettingsPage> {
                             borderRadius: BorderRadius.circular(5),
                             color: Colors.white,
                             border: Border.all(
-                                color: Colors.black.withOpacity(0.1))),
+                                color: Colors.black.withValues(alpha: 0.1))),
                         child: SwitchListTile(
                           title: Style.body(MyLocalizations.of(
                               context, 'background_tracking_title')),
@@ -169,8 +169,8 @@ class _SettingsPageState extends State<SettingsPage> {
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(5),
                           color: Colors.white,
-                          border:
-                              Border.all(color: Colors.black.withOpacity(0.1)),
+                          border: Border.all(
+                              color: Colors.black.withValues(alpha: 0.1)),
                         ),
                         child: Row(
                           children: [

--- a/lib/utils/style.dart
+++ b/lib/utils/style.dart
@@ -6,7 +6,7 @@ class Style {
   //Colors
   static final Color colorPrimary = Color(0XFFF0A402);
   static final Color textColor = Color(0XFF282828);
-  static final Color greyColor = Colors.black.withOpacity(0.5);
+  static final Color greyColor = Colors.black.withValues(alpha: 0.5);
 
   //UI
   static Icon get iconBack =>
@@ -133,7 +133,7 @@ class Style {
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         padding: EdgeInsets.symmetric(vertical: 14),
         backgroundColor: Colors.transparent,
-        foregroundColor: colorPrimary.withOpacity(0.5),
+        foregroundColor: colorPrimary.withValues(alpha: 0.5),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(3),
           side: BorderSide(color: borderColor ?? Colors.transparent),
@@ -215,7 +215,7 @@ class Style {
       controller: controller,
       style: TextStyle(
           fontSize: 15,
-          color: enabled ? textColor : textColor.withOpacity(0.6)),
+          color: enabled ? textColor : textColor.withValues(alpha: 0.6)),
       textInputAction: textInputAction ?? TextInputAction.done,
       focusNode: focusNode,
       obscureText: obscure ?? false,
@@ -244,17 +244,17 @@ class Style {
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(3.0),
           borderSide:
-              BorderSide(color: Colors.black.withOpacity(0.1), width: 1),
+              BorderSide(color: Colors.black.withValues(alpha: 0.1), width: 1),
         ),
         disabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(3.0),
           borderSide:
-              BorderSide(color: Colors.black.withOpacity(0.1), width: 1),
+              BorderSide(color: Colors.black.withValues(alpha: 0.1), width: 1),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(3.0),
           borderSide:
-              BorderSide(color: Colors.black.withOpacity(0.1), width: 1),
+              BorderSide(color: Colors.black.withValues(alpha: 0.1), width: 1),
         ),
         errorBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(3.0),


### PR DESCRIPTION
`withOpacity` was deprecated on flutter 3.27.0 -> https://stackoverflow.com/questions/79284946/why-is-withopacity-deprecated-in-flutter-3-27-0-and-what-is-its-recommended-rep
`flutter analyze`
- Before:
`34 issues found. (ran in 63.3s)`
- After:
`16 issues found. (ran in 18.7s)`