### PR TITLE
'window' is deprecated and shouldn't be used

### DIFF
--- a/lib/utils/Utils.dart
+++ b/lib/utils/Utils.dart
@@ -958,8 +958,10 @@ class Utils {
   }
 
   static ui.Locale getLanguage() {
-    var stringLanguange = ui.window.locale.languageCode;
-    var stringCountry = ui.window.locale.countryCode;
+    var stringLanguange =
+        WidgetsBinding.instance.platformDispatcher.locale.languageCode;
+    var stringCountry =
+        WidgetsBinding.instance.platformDispatcher.locale.countryCode;
 
     language = Locale('en', 'US');
 
@@ -973,7 +975,7 @@ class Utils {
         stringLanguange == 'it' ||
         stringLanguange == 'pt' ||
         stringLanguange == 'ro') {
-      language = ui.window.locale;
+      language = WidgetsBinding.instance.platformDispatcher.locale;
     }
 
     return language;


### PR DESCRIPTION
https://stackoverflow.com/questions/76312328/flutter-3-10-window-is-deprecated-and-shouldnt-be-used

Fixes 3 `flutter analyze` issues
```
   info - 'window' is deprecated and shouldn't be used. Look up the current FlutterView from the context via View.of(context) or consult the PlatformDispatcher directly instead.    
          Deprecated to prepare for the upcoming multi-window support. This feature was deprecated after v3.7.0-32.0.pre - lib\utils\Utils.dart:978:21 - deprecated_member_use
```