### PR TITLE
Fix bug of blue rectangle

### DIFF
--- a/lib/pages/forms_pages/components/biting_form.dart
+++ b/lib/pages/forms_pages/components/biting_form.dart
@@ -276,7 +276,7 @@ class _BitingFormState extends State<BitingForm> {
                                     }
                                   : null,
                               child: Container(
-                                color: Colors.blue..withValues(alpha: 0.0),
+                                color: Colors.transparent,
                                 height: mediaQuery.height * 0.1,
                                 width: mediaQuery.width * 0.18,
                               ),

--- a/lib/pages/forms_pages/components/whatsapp_camera.dart/camera_whatsapp.dart
+++ b/lib/pages/forms_pages/components/whatsapp_camera.dart/camera_whatsapp.dart
@@ -237,7 +237,7 @@ class _WhatsappCameraState extends State<WhatsappCamera>
               padding: const EdgeInsets.only(bottom: 32, right: 64),
               child: CircleAvatar(
                 radius: 20,
-                backgroundColor: Colors.black..withValues(alpha: 0.6),
+                backgroundColor: Colors.black.withValues(alpha: 0.6),
                 child: IconButton(
                   color: Colors.white,
                   onPressed: () async {


### PR DESCRIPTION
fixes #337 

Seems like the blue rectangle was used for debugging purposes and was set at blue with transparency, but this commit changed the behavior, most likely due to an extra dot by mistake (..withValues instead of .withValues) https://github.com/Mosquito-Alert/Mosquito-Alert-Mobile-App/pull/327

| Main branch  | This pull request |
| ------------- | ------------- |
| ![Image](https://github.com/user-attachments/assets/1db17e00-9f5d-4bff-a2c7-2e2297c25121) | ![image](https://github.com/user-attachments/assets/6b567e83-4046-4a6e-89ed-99139a5d22ed) |