### PR TITLE
Add Advertising ID permission for Google Analytics compliance with Play Store policy

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.CAMERA" />
 
+    <!-- Required for Google Analytics to access the Advertising ID on Android 13+ -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
+
     <application
         tools:replace="android:label"
         android:label="Mosquito Alert"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mosquito_alert_app
 description: A new Flutter project.
-version: 4.1.0+2879
+version: 4.1.0+2880
 publish_to: none
 
 


### PR DESCRIPTION
Add required AD_ID to use Analytics on SDK 33+

Although the app does not use advertising features, Google Analytics (Firebase) may access the Advertising ID for analytics purposes

No changes were made to the app's logic or UI.

Reference:
- [Google Play Policy - Advertising ID](https://support.google.com/googleplay/android-developer/answer/6048248)

| Before | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/b817a95c-0f46-428e-a9f8-fb297d17b04d) | ![image](https://github.com/user-attachments/assets/97997336-1d2c-44c5-b46e-c5f5736d6939) |
