### PR TITLE
Explicitly remove android permission ACTIVITY_RECOGNITION

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
     <!-- Required for Google Analytics to access the Advertising ID on Android 13+ -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
+    <!-- Remove ACTIVITY_RECOGNITION permission -->
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" tools:node="remove" />
+
     <application
         tools:replace="android:label"
         android:label="Mosquito Alert"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mosquito_alert_app
 description: A new Flutter project.
-version: 4.1.0+2883
+version: 4.1.0+2884
 publish_to: none
 
 


### PR DESCRIPTION
Google Play is rejecting the app update due to inexact health declaration and use of ACTIVITY_RECOGNITION despite that we already removed this permission that was inside the previous geolocation dependency

https://stackoverflow.com/questions/8257412/remove-extra-unwanted-permissions-from-manifest-android