### PR TITLE
Replace discontinued pkg flutter_markdown to markdown

### DIFF
--- a/lib/pages/settings_pages/gallery_page.dart
+++ b/lib/pages/settings_pages/gallery_page.dart
@@ -1,7 +1,8 @@
-import 'package:flutter/material.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart' as html;
 import 'package:intro_slider/intro_slider.dart';
+import 'package:markdown/markdown.dart';
 import 'package:mosquito_alert_app/utils/MyLocalizations.dart';
 import 'package:mosquito_alert_app/utils/style.dart';
 
@@ -135,8 +136,8 @@ class _GalleryPageState extends State<GalleryPage> {
                   margin: EdgeInsets.all(20.0),
                   child: Padding(
                     padding: const EdgeInsets.only(bottom: 0.0),
-                    child: MarkdownBody(
-                      data: currentSlide.description!,
+                    child: html.Html(
+                      data: markdownToHtml(currentSlide.description!),
                     ),
                   )),
             ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -525,14 +525,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_markdown:
-    dependency: "direct main"
-    description:
-      name: flutter_markdown
-      sha256: "255b00afa1a7bad19727da6a7780cf3db6c3c12e68d302d85e0ff1fdf173db9e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.4+3"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -930,7 +922,7 @@ packages:
     source: hosted
     version: "0.1.3-main.0"
   markdown:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: markdown
       sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   geocoding: ^4.0.0
   dio: ^5.8.0+1
   flutter_image_compress: ^2.3.0
-  flutter_markdown: ^0.7.4+3
+  markdown: ^7.3.0
   firebase_messaging: ^15.2.4
   firebase_core: ^3.13.0
   auto_size_text: ^3.0.0


### PR DESCRIPTION
When running `fvm flutter outdated`:

```
Package Name                               Current              Upgradable           Resolvable           Latest              

direct dependencies:
flutter_markdown                           *0.7.4+3             0.7.7+1              0.7.7+1              0.7.7+1             (discontinued)
```