### PR TITLE
Always use port 443 to avoid infinite loading spinner on app start

### DIFF
--- a/assets/config/prod.json
+++ b/assets/config/prod.json
@@ -1,3 +1,4 @@
 {
+    "baseUrl": "https://api.mosquitoalert.com/v1",
     "useAuth": true
 }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -9,8 +9,11 @@ class ApiService {
   late final MosquitoAlert _client;
 
   ApiService._({required this.authProvider, baseUrl}) {
+    final uri = Uri.parse(baseUrl);
+    final baseUrlWithPort = uri.replace(port: 443).toString();
+
     final BaseOptions options = BaseOptions(
-      baseUrl: baseUrl,
+      baseUrl: baseUrlWithPort,
       connectTimeout: const Duration(milliseconds: 5000),
       receiveTimeout: const Duration(
           milliseconds:
@@ -26,7 +29,7 @@ class ApiService {
           authProvider.setAccessToken(accessToken: newAccessToken);
         }));
 
-    _client = MosquitoAlert(dio: _dio);
+    _client = MosquitoAlert(dio: _dio, basePathOverride: baseUrlWithPort);
   }
 
   static Future<ApiService> init({required AuthProvider authProvider}) async {


### PR DESCRIPTION
Related to #432 

With the new api, the requests are sometimes not using port 443 and therefore fail, leaving the app unusable. 
This PR sets port to be always 443 which is the one needed by the server