### PR TITLE
All reports using same 'outdoors' icon

### DIFF
--- a/lib/pages/reports/adult/pages/environment_question_page.dart
+++ b/lib/pages/reports/adult/pages/environment_question_page.dart
@@ -39,7 +39,7 @@ class _EnvironmentQuestionPageState extends State<EnvironmentQuestionPage> {
       'value': 'outdoors',
       'titleKey': 'question_4_answer_43',
       'description': '(HC) Garden, park, street, or any outdoor space',
-      'icon': Icons.nature,
+      'icon': Icons.park,
     },
   ];
 


### PR DESCRIPTION
fixes #564 

<img width="200" height="425" alt="Screenshot 2025-10-14 at 20 37 17" src="https://github.com/user-attachments/assets/c1aecab5-2d6a-41c5-b810-d353799623c6" />

<img width="200" height="425" alt="Screenshot 2025-10-14 at 20 37 53" src="https://github.com/user-attachments/assets/a4d58000-8b73-4e33-9c61-d0fcc438c3b8" />
