### PR TITLE
Remove url_launcher as not directly used

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1584,7 +1584,7 @@ packages:
     source: hosted
     version: "0.7.0"
   url_launcher:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   auto_size_text: ^3.0.0
   device_info_plus: ^11.3.0
   package_info_plus: ^9.0.0
-  url_launcher: ^6.3.1
   intro_slider: ^3.0.10
   permission_handler: ^11.4.0
   language_picker: ^0.4.5


### PR DESCRIPTION
It is a transitive dependency (used by other library), but not used directly in the project