### PR TITLE
Fix CI failure by freeing up disk space

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Build debug appbundle (avoids test loader timeouts)
       run: flutter build appbundle --debug
 
-    - name: Free up disk space that come by default with the emulator
+    - name: Free up disk space that comes by default with the emulator
       run: |
         # Remove large unused packages
         sudo apt-get remove -y --purge azure-cli google-chrome-stable firefox \


### PR DESCRIPTION
Fix issue in the CI workflow:
```
FATAL        | Not enough space to create userdata partition. Available: 4746.74 MB at /home/runner/.android/avd/test.avd, need 7372.80 MB.
```

Removed apps/data/tools that are installed by default in the emulator but are not needed to test the app