### PR TITLE
Fix silent deletion of offline reports on sync failure

### DIFF
--- a/lib/core/outbox/outbox_mixin.dart
+++ b/lib/core/outbox/outbox_mixin.dart
@@ -29,16 +29,20 @@ mixin OutboxMixin<
   /// Repository must implement method dispatcher
   Future<void> execute(OutboxTask task) async {
     final item = task.item;
-    await outbox.remove(item.id);
     try {
       await task.run();
     } catch (error) {
-      // Only runs if task.run() fails
+      // Only runs if task.run() fails. The outbox entry is left in place so
+      // the task can be retried on the next sync cycle.
       await schedule(task, runNow: false);
       return; // stop further execution
     }
 
-    // Runs only if task.run() succeeded
+    // Only remove the outbox entry (and associated local item) after the
+    // task has successfully completed. Removing it beforehand risked losing
+    // the record entirely if the action threw after the remove but before
+    // reschedule could persist it.
+    await outbox.remove(item.id);
     if (item.operation == OutBoxOperation.create) {
       final request = createRequestFactory(item.payload);
       await itemBox.delete(request.localId);

--- a/lib/features/reports/data/report_repository.dart
+++ b/lib/features/reports/data/report_repository.dart
@@ -83,14 +83,13 @@ abstract class ReportRepository<
         switch (item.operation) {
           case OutBoxOperation.create:
             final request = createRequestFactory(item.payload);
-            TReport newReport;
-            try {
-              newReport = await _createApiOrLocal(request: request);
-            } catch (_) {
-              break;
-            }
+            // Let any exception propagate so the outbox can reschedule the
+            // task. Previously this block swallowed all errors and allowed
+            // `execute()` to treat the attempt as a success, which silently
+            // deleted the local report without it ever reaching the server.
+            final newReport = await _createApiOrLocal(request: request);
             if (newReport.localId != null) {
-              // Throw exception to re-schedule
+              // Still offline / server unreachable; signal a retry.
               throw Exception("Failed to create report");
             }
             break;


### PR DESCRIPTION
When an offline-created report's POST failed with a 4xx (or any non-DioException thrown inside sendCreateToApi, e.g. a missing photo file), the create action in ReportRepository caught the error and returned normally. OutboxMixin.execute() then treated the attempt as a success and deleted the local item from itemBox, even though the report had never reached the server. The report disappeared from 'My Reports' after the next refresh.

Two changes:

1. report_repository.dart: remove the blanket catch in the create outbox action so exceptions propagate. execute()'s catch block then reschedules the task as intended.

2. outbox_mixin.dart: move outbox.remove() to after a successful task.run(). Previously the outbox entry was removed before the task ran, so any failure path that couldn't reschedule cleanly would orphan the item.