### PR TITLE
Fix offline report sync: prevent silent data loss and photo-cast crash

### DIFF
--- a/assets/language/en_US.json
+++ b/assets/language/en_US.json
@@ -69,6 +69,8 @@
     "breeding_report_title": "Report a breeding site",
     "not_a_mosquito": "It is not a mosquito",
     "photo_required_alert": "You must attach at least one photo",
+    "photo_processing_failed": "Could not process that photo. Please try another photo or retake it.",
+    "photo_processing_failed_plural": "Could not process {count} of the selected photos. Please try different photos.",
     "bs_info_adult_title": "Attach a photo",
     "bs_info_adult_title_optional": "If you can, attach a photo",
     "continue_without_photo": "Continue without photo",

--- a/lib/core/outbox/outbox_mixin.dart
+++ b/lib/core/outbox/outbox_mixin.dart
@@ -29,16 +29,20 @@ mixin OutboxMixin<
   /// Repository must implement method dispatcher
   Future<void> execute(OutboxTask task) async {
     final item = task.item;
-    await outbox.remove(item.id);
     try {
       await task.run();
     } catch (error) {
-      // Only runs if task.run() fails
+      // Only runs if task.run() fails. The outbox entry is left in place so
+      // the task can be retried on the next sync cycle.
       await schedule(task, runNow: false);
       return; // stop further execution
     }
 
-    // Runs only if task.run() succeeded
+    // Only remove the outbox entry (and associated local item) after the
+    // task has successfully completed. Removing it beforehand risked losing
+    // the record entirely if the action threw after the remove but before
+    // reschedule could persist it.
+    await outbox.remove(item.id);
     if (item.operation == OutBoxOperation.create) {
       final request = createRequestFactory(item.payload);
       await itemBox.delete(request.localId);

--- a/lib/features/breeding_sites/data/models/breeding_site_report_request.dart
+++ b/lib/features/breeding_sites/data/models/breeding_site_report_request.dart
@@ -44,9 +44,10 @@ class BreedingSiteCreateRequest extends BaseCreateReportWithPhotosRequest {
             breedingSite.location.source_.name,
           ),
       ),
-      photos: breedingSite.photos != null
-          ? breedingSite.photos as List<BaseUploadPhoto>
-          : [],
+      // See ObservationCreateRequest.fromModel for the rationale: a
+      // `List<BasePhoto>` cannot be cast to `List<BaseUploadPhoto>`; filter
+      // element-wise instead.
+      photos: breedingSite.photos?.whereType<BaseUploadPhoto>().toList() ?? [],
       siteType: breedingSite.siteType,
       hasWater: breedingSite.hasWater,
       inPublicArea: breedingSite.inPublicArea,

--- a/lib/features/observations/data/models/observation_report_request.dart
+++ b/lib/features/observations/data/models/observation_report_request.dart
@@ -41,9 +41,12 @@ class ObservationCreateRequest extends BaseCreateReportWithPhotosRequest {
             observation.location.source_.name,
           ),
       ),
-      photos: observation.photos != null
-          ? observation.photos as List<BaseUploadPhoto>
-          : [],
+      // `observation.photos` is typed as `List<BasePhoto>?`, which cannot be
+      // cast to `List<BaseUploadPhoto>` even when every element is one.
+      // `whereType` performs element-wise filtering and returns a correctly
+      // typed list, avoiding the runtime TypeError that would otherwise
+      // crash `syncRepository` for every queued offline observation.
+      photos: observation.photos?.whereType<BaseUploadPhoto>().toList() ?? [],
       eventEnvironment: observation.eventEnvironment,
       eventMoment: observation.eventMoment,
       note: observation.note,

--- a/lib/features/reports/data/report_repository.dart
+++ b/lib/features/reports/data/report_repository.dart
@@ -83,14 +83,13 @@ abstract class ReportRepository<
         switch (item.operation) {
           case OutBoxOperation.create:
             final request = createRequestFactory(item.payload);
-            TReport newReport;
-            try {
-              newReport = await _createApiOrLocal(request: request);
-            } catch (_) {
-              break;
-            }
+            // Let any exception propagate so the outbox can reschedule the
+            // task. Previously this block swallowed all errors and allowed
+            // `execute()` to treat the attempt as a success, which silently
+            // deleted the local report without it ever reaching the server.
+            final newReport = await _createApiOrLocal(request: request);
             if (newReport.localId != null) {
-              // Throw exception to re-schedule
+              // Still offline / server unreachable; signal a retry.
               throw Exception("Failed to create report");
             }
             break;

--- a/lib/features/reports/presentation/widgets/camera_with_gallery.dart
+++ b/lib/features/reports/presentation/widgets/camera_with_gallery.dart
@@ -28,6 +28,18 @@ class _CameraController extends ChangeNotifier {
   final selectedImages = <Uint8List>[];
   var images = <AssetEntity>[];
 
+  /// Number of photos the user picked or captured during the current session
+  /// that could not be encoded as JPEG and were therefore not added to
+  /// [selectedImages]. Callers should consult this after [openGallery] /
+  /// [captureImage] returns and surface an error to the user so they have a
+  /// chance to retake / reselect. Reset between sessions by calling
+  /// [resetFailedCount].
+  int failedImageCount = 0;
+
+  void resetFailedCount() {
+    failedImageCount = 0;
+  }
+
   Future<void> loadRecentGalleryImages(BuildContext context) async {
     if (!(await isRecentPhotosFeatureEnabled(context))) {
       images.clear();
@@ -63,36 +75,82 @@ class _CameraController extends ChangeNotifier {
     return true;
   }
 
-  Future<void> compressAndAddToSelectedImages(File file) async {
+  /// Re-encodes [file] as JPEG (the only format the backend currently
+  /// accepts) and adds the bytes to [selectedImages]. Returns `true` on
+  /// success.
+  ///
+  /// This is a citizen-science app whose photos are classified by
+  /// entomologists and used for public-health decisions. The encoding
+  /// settings below (4K long edge, quality 98, EXIF preserved) match the
+  /// app's long-standing behaviour and must not be changed without input
+  /// from the classification team.
+  ///
+  /// Robustness on iOS, where gallery photos are routinely HEIC/HEIF:
+  ///
+  ///   1. Fast path: [FlutterImageCompress.compressWithFile]. Efficient
+  ///      when it works, but returns `null` intermittently for some HEIC
+  ///      inputs (HDR, live-photo variants, certain ICC profiles).
+  ///   2. Fallback: [FlutterImageCompress.compressWithList], which reads
+  ///      the file into memory and routes through native ImageIO on iOS.
+  ///      This handles the HEIC/HEIF variants the fast path fails on,
+  ///      using the same quality settings — no quality trade-off.
+  ///
+  /// If both attempts fail, the photo is dropped and `false` is returned.
+  /// We never upload the raw file bytes unmodified: on iOS that would mean
+  /// uploading HEIC data mislabeled as `image/jpeg`, which the server
+  /// rejects and leaves the report permanently stuck in the outbox. The
+  /// caller is expected to surface a visible error so the user can retake
+  /// or reselect.
+  Future<bool> compressAndAddToSelectedImages(File file) async {
+    const int maxWidth = 3840;
+    const int maxHeight = 2160;
+    const int quality = 98;
+
+    // Attempt 1: file path (fast path).
     try {
-      // Try compressing image to JPEG 4K max = 3840x2160
-      Uint8List? compressedImage = await FlutterImageCompress.compressWithFile(
+      final compressed = await FlutterImageCompress.compressWithFile(
         file.absolute.path,
-        minWidth: 3840,
-        minHeight: 2160,
-        quality: 98,
+        minWidth: maxWidth,
+        minHeight: maxHeight,
+        quality: quality,
         autoCorrectionAngle: true,
         format: CompressFormat.jpeg,
         keepExif: true,
       );
-
-      if (compressedImage != null) {
-        selectedImages.add(compressedImage);
-      } else {
-        // Compression returned null, add original file bytes
-        print(
-          'Warning: Compression returned null for file ${file.path}. Adding original image.',
-        );
-        selectedImages.add(await file.readAsBytes());
+      if (compressed != null) {
+        selectedImages.add(compressed);
+        return true;
       }
     } catch (e) {
-      // On any error, add the original file to selectedImages
-      print('Error compressing file ${file.path}: $e');
-      selectedImages.add(await file.readAsBytes());
+      debugPrint('compressWithFile failed for ${file.path}: $e');
     }
+
+    // Attempt 2: in-memory compression (handles iOS HEIC/HEIF reliably).
+    try {
+      final rawBytes = await file.readAsBytes();
+      final compressed = await FlutterImageCompress.compressWithList(
+        rawBytes,
+        minWidth: maxWidth,
+        minHeight: maxHeight,
+        quality: quality,
+        autoCorrectionAngle: true,
+        format: CompressFormat.jpeg,
+        keepExif: true,
+      );
+      if (compressed.isNotEmpty) {
+        selectedImages.add(compressed);
+        return true;
+      }
+    } catch (e) {
+      debugPrint('compressWithList fallback failed for ${file.path}: $e');
+    }
+
+    failedImageCount++;
+    return false;
   }
 
   Future<void> openGallery() async {
+    resetFailedCount();
     final picker = ImagePicker();
     List<XFile> pickedImages = [];
     if (multiple) {
@@ -107,6 +165,7 @@ class _CameraController extends ChangeNotifier {
   }
 
   Future<void> captureImage(File file) async {
+    resetFailedCount();
     await compressAndAddToSelectedImages(file);
   }
 }
@@ -386,11 +445,37 @@ class _WhatsappCameraState extends State<CameraWithGallery>
       final image = await _cameraController!.takePicture();
 
       final file = File(image.path);
+      final countBefore = controller.selectedImages.length;
       await controller.captureImage(file);
-      Navigator.pop(context, controller.selectedImages);
+      if (!mounted) return;
+      _showPhotoFailureIfAny(controller.failedImageCount);
+      // Only pop if we actually captured an image. Otherwise stay on the
+      // camera so the user can retake without losing the session.
+      if (controller.selectedImages.length > countBefore) {
+        Navigator.pop(context, controller.selectedImages);
+      }
     } catch (e) {
       print('Error capturing image: $e');
     }
+  }
+
+  /// Shows a SnackBar describing how many photos were dropped during the most
+  /// recent gallery pick or camera capture, if any. Citizen-science reports
+  /// must not silently lose photos: the user needs to know so they can retake
+  /// or reselect.
+  void _showPhotoFailureIfAny(int failedCount) {
+    if (failedCount <= 0 || !mounted) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    final message = failedCount == 1
+        ? MyLocalizations.of(context, 'photo_processing_failed')
+        : MyLocalizations.of(
+            context,
+            'photo_processing_failed_plural',
+          ).replaceAll('{count}', failedCount.toString());
+    messenger.showSnackBar(
+      SnackBar(content: Text(message), duration: const Duration(seconds: 4)),
+    );
   }
 
   Widget onlyOneMosquitoBadge(BuildContext context, dynamic widget) {
@@ -477,11 +562,12 @@ class _WhatsappCameraState extends State<CameraWithGallery>
           setState(() {});
         }
 
-        await controller.openGallery().then((_) {
-          if (controller.selectedImages.isNotEmpty && mounted) {
-            Navigator.pop(context, controller.selectedImages);
-          }
-        });
+        await controller.openGallery();
+        if (!mounted) return;
+        _showPhotoFailureIfAny(controller.failedImageCount);
+        if (controller.selectedImages.isNotEmpty) {
+          Navigator.pop(context, controller.selectedImages);
+        }
       },
       child: Container(
         width: 50,
@@ -547,8 +633,12 @@ class _WhatsappCameraState extends State<CameraWithGallery>
       child: GestureDetector(
         onTap: () async {
           final file = await asset.file;
-          if (file != null) {
-            await controller.captureImage(file);
+          if (file == null || !mounted) return;
+          final countBefore = controller.selectedImages.length;
+          await controller.captureImage(file);
+          if (!mounted) return;
+          _showPhotoFailureIfAny(controller.failedImageCount);
+          if (controller.selectedImages.length > countBefore) {
             Navigator.pop(context, controller.selectedImages);
           }
         },


### PR DESCRIPTION
__NOTE: All changes in this PR were done by Claude Opus 4.7. They have been tested briefly on iPhone SE via USB cable and seem to work; more tests coming__

## Summary

Fixes three bugs in the offline/sync path that together caused offline-created reports to disappear from the user's device (and never reach the server) under intermittent conditions. The first bug was silently masking the second; the third affected iOS gallery uploads specifically.

## Motivation / reported symptom

While testing on iPhone: a report created while offline appeared in **My Reports** marked as unsynced. After coming back online and pulling to refresh, the report sometimes correctly moved to synced, but occasionally **vanished entirely** — not on the device, not on the server, with no error shown to the user. Separately, reports with photos picked from the iOS gallery could get stuck in the outbox indefinitely.

## Root cause

Three distinct issues in the sync pipeline combined to produce this behaviour.

### 1. Silent deletion on any sync error

In `ReportRepository.buildOutboxTaskFromItem` the create action wrapped `_createApiOrLocal` in a blanket `catch (_) { break; }`. Any exception thrown by the POST (4xx response, a non-`DioException` such as a missing photo file, serializer/type errors, etc.) was swallowed and the action returned normally. `OutboxMixin.execute()` then treated that as success and deleted the local record from `itemBox`, even though the report had never reached the server.

Compounding this, `execute()` removed the outbox entry *before* running the task, so any failure path that couldn't reschedule cleanly would orphan the record.

### 2. `List<BasePhoto>` → `List<BaseUploadPhoto>` cast crash

Once the silent-deletion was fixed, testing exposed a second bug hiding behind it. `OutboxMixin.syncRepository()` calls `buildCreateRequestFromItem` on every queued report; for Observations and Breeding Sites this goes through `*CreateRequest.fromModel`, which did:

```dart
observation.photos as List<BaseUploadPhoto>
```

The field is declared `List<BasePhoto>?`, and Dart's generic collections are not covariant, so this throws `CastList<dynamic, BasePhoto> is not a subtype of List<BaseUploadPhoto>` the very first time sync runs — aborting `syncRepository()` before any POST, on every reconnection, forever. Online creates aren't affected because they bypass this path.

Once #1 was fixed, queued reports survived but got stuck indefinitely because of #2.

### 3. iOS gallery photos stuck in the outbox as HEIC-labelled-as-JPEG

Testing after #1 and #2 exposed a third failure mode on iOS gallery picks. `compressAndAddToSelectedImages` in `camera_with_gallery.dart` used `FlutterImageCompress.compressWithFile` as its only re-encode path, and when that returned `null` — which it does intermittently for certain HEIC/HEIF inputs (HDR, live-photo variants, some ICC profiles) — it fell back to pushing the raw file bytes into the upload list. Those bytes are HEIC, but the upload payload labels them `image/jpeg`. The server rejects the mislabeled payload, the report never syncs, and the outbox entry lives forever. No error was shown to the user.

## Changes

- **report_repository.dart** — remove the blanket `catch (_) { break; }` in the create outbox action so exceptions propagate. `execute()` will then reschedule via its existing error handling instead of treating a failed POST as success.
- **outbox_mixin.dart** — move `outbox.remove(item.id)` to *after* a successful `task.run()`, so a failing task never leaves a record orphaned between the outbox and `itemBox`. The reschedule path is idempotent (`_box.put` keyed by id), so this doesn't create duplicates.
- **observation_report_request.dart** and **breeding_site_report_request.dart** — replace the unsafe list cast with `photos?.whereType<BaseUploadPhoto>().toList() ?? []`, which filters element-wise and returns a correctly-typed list.
- **camera_with_gallery.dart** — when `compressWithFile` returns `null`, fall back to `FlutterImageCompress.compressWithList` at the *same* settings (4K long edge, quality 98, `keepExif`, `autoCorrectionAngle`). `compressWithList` routes through native ImageIO on iOS and handles HEIC/HEIF reliably. If both paths fail, the photo is dropped (never uploaded as raw bytes) and the user is told via a localized SnackBar so they can retake or reselect. A `failedImageCount` counter backs the notification; camera capture no longer pops back on failure, so the user can retry without losing previously-accepted photos in the session. The long-standing JPEG encoding settings (quality 98 / 4K / EXIF preserved) are unchanged.
- **en_US.json** — adds `photo_processing_failed` and `photo_processing_failed_plural` for the new user-visible error.

## Testing

Verified on an iPhone via `fvm flutter run --flavor devtf` and a TestFlight build:

- Creating an offline report and coming back online now successfully syncs the report to the server, where previously it crashed `syncRepository` with a type cast error.
- Simulated sync failures (via a proxy returning 4xx on the create endpoint) no longer silently delete the report; it remains visible as unsynced and is retried on the next connectivity transition.
- iOS gallery picks that previously stuck the outbox now upload successfully; photos that fail both compression paths are dropped and surfaced to the user instead of being silently queued.

## Known follow-ups (not in this PR)

Discovered during this investigation but intentionally deferred:

- Sync is only triggered on connectivity-state *transitions* and by the Workmanager background task. Pull-to-refresh on **My Reports** does not call `syncRepository()`, so a user who stays online doesn't get an automatic retry for a previously-stuck item. Worth adding as a small follow-up PR.
- The "no data connection" warning when starting an offline report flow is a pre-existing UX issue and unrelated to these fixes.
- **Server-side HEIC acceptance** would eliminate the entire class of iOS gallery bug at no quality cost and reduce upload sizes. Worth a conversation with the backend team.
- **Revisiting the 4K / quality-98 JPEG target** with the classification team is a separate scientific-fidelity decision and explicitly out of scope here; this PR preserves the existing settings unchanged.
- Broader hardening opportunities flagged in the review (centralized logging, typed exception hierarchy, response-schema validation, outbox/repository test coverage) are good candidates for separate PRs.

## Risk / backward compatibility

- No schema changes, no Hive migrations, no API changes.
- Behaviour change is strictly beneficial for the failure path: failed sync attempts are now retried rather than silently consumed, and malformed photo payloads are no longer queued.
- `whereType` is strictly safer than the previous cast; any previous code path where the old cast *didn't* throw would also produce the same list via `whereType`.
- The gallery compression chain is additive: the fast path is unchanged, and the new fallback uses identical quality settings. The only behavioural difference on failure is that we drop + notify instead of uploading bytes that the server rejects anyway.