### PR TITLE
Fix/outbox silent report deletion

### DIFF
--- a/lib/core/outbox/outbox_mixin.dart
+++ b/lib/core/outbox/outbox_mixin.dart
@@ -29,16 +29,20 @@ mixin OutboxMixin<
   /// Repository must implement method dispatcher
   Future<void> execute(OutboxTask task) async {
     final item = task.item;
-    await outbox.remove(item.id);
     try {
       await task.run();
     } catch (error) {
-      // Only runs if task.run() fails
+      // Only runs if task.run() fails. The outbox entry is left in place so
+      // the task can be retried on the next sync cycle.
       await schedule(task, runNow: false);
       return; // stop further execution
     }
 
-    // Runs only if task.run() succeeded
+    // Only remove the outbox entry (and associated local item) after the
+    // task has successfully completed. Removing it beforehand risked losing
+    // the record entirely if the action threw after the remove but before
+    // reschedule could persist it.
+    await outbox.remove(item.id);
     if (item.operation == OutBoxOperation.create) {
       final request = createRequestFactory(item.payload);
       await itemBox.delete(request.localId);

--- a/lib/features/breeding_sites/data/models/breeding_site_report_request.dart
+++ b/lib/features/breeding_sites/data/models/breeding_site_report_request.dart
@@ -44,9 +44,10 @@ class BreedingSiteCreateRequest extends BaseCreateReportWithPhotosRequest {
             breedingSite.location.source_.name,
           ),
       ),
-      photos: breedingSite.photos != null
-          ? breedingSite.photos as List<BaseUploadPhoto>
-          : [],
+      // See ObservationCreateRequest.fromModel for the rationale: a
+      // `List<BasePhoto>` cannot be cast to `List<BaseUploadPhoto>`; filter
+      // element-wise instead.
+      photos: breedingSite.photos?.whereType<BaseUploadPhoto>().toList() ?? [],
       siteType: breedingSite.siteType,
       hasWater: breedingSite.hasWater,
       inPublicArea: breedingSite.inPublicArea,

--- a/lib/features/observations/data/models/observation_report_request.dart
+++ b/lib/features/observations/data/models/observation_report_request.dart
@@ -41,9 +41,12 @@ class ObservationCreateRequest extends BaseCreateReportWithPhotosRequest {
             observation.location.source_.name,
           ),
       ),
-      photos: observation.photos != null
-          ? observation.photos as List<BaseUploadPhoto>
-          : [],
+      // `observation.photos` is typed as `List<BasePhoto>?`, which cannot be
+      // cast to `List<BaseUploadPhoto>` even when every element is one.
+      // `whereType` performs element-wise filtering and returns a correctly
+      // typed list, avoiding the runtime TypeError that would otherwise
+      // crash `syncRepository` for every queued offline observation.
+      photos: observation.photos?.whereType<BaseUploadPhoto>().toList() ?? [],
       eventEnvironment: observation.eventEnvironment,
       eventMoment: observation.eventMoment,
       note: observation.note,

--- a/lib/features/reports/data/report_repository.dart
+++ b/lib/features/reports/data/report_repository.dart
@@ -83,14 +83,13 @@ abstract class ReportRepository<
         switch (item.operation) {
           case OutBoxOperation.create:
             final request = createRequestFactory(item.payload);
-            TReport newReport;
-            try {
-              newReport = await _createApiOrLocal(request: request);
-            } catch (_) {
-              break;
-            }
+            // Let any exception propagate so the outbox can reschedule the
+            // task. Previously this block swallowed all errors and allowed
+            // `execute()` to treat the attempt as a success, which silently
+            // deleted the local report without it ever reaching the server.
+            final newReport = await _createApiOrLocal(request: request);
             if (newReport.localId != null) {
-              // Throw exception to re-schedule
+              // Still offline / server unreachable; signal a retry.
               throw Exception("Failed to create report");
             }
             break;


### PR DESCRIPTION

__NOTE: All changes in this PR were done by Claude Opus 4.7. They have been tested briefly on iPhone SE via USB cable and seem to work; more tests coming.__

## Summary

Fixes two bugs in the offline outbox path that together caused offline-created reports to disappear from the user's device (and never reach the server) under intermittent conditions. The first bug was silently masking the second.

## Motivation / reported symptom

While testing on iPhone: a report created while offline appeared in **My Reports** marked as unsynced. After coming back online and pulling to refresh, the report sometimes correctly moved to synced, but occasionally **vanished entirely** — not on the device, not on the server, with no error shown to the user.

## Root cause

Two distinct issues in the sync pipeline combined to produce this behaviour.

### 1. Silent deletion on any sync error

In `ReportRepository.buildOutboxTaskFromItem` the create action wrapped `_createApiOrLocal` in a blanket `catch (_) { break; }`. Any exception thrown by the POST (4xx response, a non-`DioException` such as a missing photo file, serializer/type errors, etc.) was swallowed and the action returned normally. `OutboxMixin.execute()` then treated that as success and deleted the local record from `itemBox`, even though the report had never reached the server.

Compounding this, `execute()` removed the outbox entry *before* running the task, so any failure path that couldn't reschedule cleanly would orphan the record.

### 2. `List<BasePhoto>` → `List<BaseUploadPhoto>` cast crash

Once the silent-deletion was fixed, testing exposed a second bug hiding behind it. `OutboxMixin.syncRepository()` calls `buildCreateRequestFromItem` on every queued report; for Observations and Breeding Sites this goes through `*CreateRequest.fromModel`, which did:

```dart
observation.photos as List<BaseUploadPhoto>
```

The field is declared `List<BasePhoto>?`, and Dart's generic collections are not covariant, so this throws `CastList<dynamic, BasePhoto> is not a subtype of List<BaseUploadPhoto>` the very first time sync runs — aborting `syncRepository()` before any POST, on every reconnection, forever. Online creates aren't affected because they bypass this path.

Once #1 was fixed, queued reports survived but got stuck indefinitely because of #2.

## Changes

- **report_repository.dart** — remove the blanket `catch (_) { break; }` in the create outbox action so exceptions propagate. `execute()` will then reschedule via its existing error handling instead of treating a failed POST as success.
- **outbox_mixin.dart** — move `outbox.remove(item.id)` to *after* a successful `task.run()`, so a failing task never leaves a record orphaned between the outbox and `itemBox`. The reschedule path is idempotent (`_box.put` keyed by id), so this doesn't create duplicates.
- **observation_report_request.dart** and **breeding_site_report_request.dart** — replace the unsafe list cast with `photos?.whereType<BaseUploadPhoto>().toList() ?? []`, which filters element-wise and returns a correctly-typed list.

## Testing

Verified on an iPhone via `fvm flutter run --flavor devtf`:

- Creating an offline report and coming back online now successfully syncs the report to the server, where previously it crashed `syncRepository` with a type cast error.
- Simulated sync failures (via a proxy returning 4xx on the create endpoint) no longer silently delete the report; it remains visible as unsynced and is retried on the next connectivity transition.

## Known follow-ups (not in this PR)

Discovered during this investigation but intentionally deferred:

- During testing, a separate issue surfaced with reports that include photos chosen from the iPhone gallery: uploads to `apidev.mosquitoalert.com` fail with the server (or a proxy) closing the TCP connection mid-upload (client sees `ECONNRESET` / `EPIPE`, no HTTP response). Camera-captured photos succeed; gallery-sourced JPEGs in the ~2–3 MB range fail. Root cause still under investigation with the backend team; unrelated to the outbox/sync code changed here.
- Sync is only triggered on connectivity-state *transitions* and by the Workmanager background task. Pull-to-refresh on **My Reports** does not call `syncRepository()`, so a user who stays online doesn't get an automatic retry for a previously-stuck item. Worth adding as a small follow-up PR.
- The "no data connection" warning when starting an offline report flow is a pre-existing UX issue and unrelated to these fixes.
- Broader hardening opportunities flagged in the review (centralized logging, typed exception hierarchy, response-schema validation, outbox/repository test coverage) are good candidates for separate PRs.

## Risk / backward compatibility

- No schema changes, no Hive migrations, no API changes.
- Behaviour change is strictly beneficial for the failure path: failed sync attempts are now retried rather than silently consumed.
- `whereType` is strictly safer than the previous cast; any previous code path where the old cast *didn't* throw would also produce the same list via `whereType`.