### PR TITLE
Migrate legacy local reports during upgrade

### DIFF
--- a/lib/features/reports/data/legacy_local_reports_migration.dart
+++ b/lib/features/reports/data/legacy_local_reports_migration.dart
@@ -1,0 +1,422 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:hive_ce/hive.dart';
+import 'package:mosquito_alert/mosquito_alert.dart';
+import 'package:mosquito_alert_app/features/bites/data/bite_repository.dart';
+import 'package:mosquito_alert_app/features/bites/domain/models/bite_report.dart';
+import 'package:mosquito_alert_app/features/breeding_sites/data/breeding_site_repository.dart';
+import 'package:mosquito_alert_app/features/breeding_sites/domain/models/breeding_site_report.dart';
+import 'package:mosquito_alert_app/features/observations/data/observation_repository.dart';
+import 'package:mosquito_alert_app/features/observations/domain/models/observation_report.dart';
+import 'package:mosquito_alert_app/features/reports/domain/models/base_report.dart';
+import 'package:mosquito_alert_app/features/reports/domain/models/photo.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> migrateLegacyLocalReports() async {
+  final prefs = await SharedPreferences.getInstance();
+  final savedReports = List<String>.from(
+    prefs.getStringList('reportsList') ?? const <String>[],
+  );
+  final savedImages = List<String>.from(
+    prefs.getStringList('imagesList') ?? const <String>[],
+  );
+
+  if (savedReports.isEmpty && savedImages.isEmpty) {
+    return;
+  }
+
+  final remainingReports = <String>[];
+  final remainingImages = <String>[];
+  final imagesByVersion = <String, List<_LegacySavedImage>>{};
+
+  for (final rawImage in savedImages) {
+    final image = _LegacySavedImage.tryParse(rawImage);
+    if (image == null || image.versionUuid == null) {
+      remainingImages.add(rawImage);
+      continue;
+    }
+    imagesByVersion.putIfAbsent(image.versionUuid!, () => []).add(image);
+  }
+
+  for (final rawReport in savedReports) {
+    final reportJson = _decodeJsonObject(rawReport);
+    if (reportJson == null) {
+      remainingReports.add(rawReport);
+      continue;
+    }
+
+    final versionUuid = _nullableString(reportJson['version_UUID']);
+    final linkedImages = versionUuid != null
+        ? imagesByVersion.remove(versionUuid) ?? const <_LegacySavedImage>[]
+        : const <_LegacySavedImage>[];
+
+    try {
+      final migratedReport = _LegacyReportMigrator(
+        reportJson,
+      ).migrate(linkedImages: linkedImages);
+      if (migratedReport == null) {
+        remainingReports.add(rawReport);
+        remainingImages.addAll(linkedImages.map((image) => image.raw));
+        continue;
+      }
+      await _storeMigratedReport(migratedReport);
+    } catch (_) {
+      remainingReports.add(rawReport);
+      remainingImages.addAll(linkedImages.map((image) => image.raw));
+    }
+  }
+
+  for (final orphanImages in imagesByVersion.values) {
+    remainingImages.addAll(orphanImages.map((image) => image.raw));
+  }
+
+  await prefs.setStringList('reportsList', remainingReports);
+  await prefs.setStringList('imagesList', remainingImages);
+}
+
+Future<void> _storeMigratedReport(BaseReportModel report) async {
+  switch (report) {
+    case ObservationReport observation:
+      await Hive.box<ObservationReport>(
+        ObservationRepository.itemBoxName,
+      ).put(observation.localId, observation);
+    case BiteReport bite:
+      await Hive.box<BiteReport>(
+        BiteRepository.itemBoxName,
+      ).put(bite.localId, bite);
+    case BreedingSiteReport breedingSite:
+      await Hive.box<BreedingSiteReport>(
+        BreedingSiteRepository.itemBoxName,
+      ).put(breedingSite.localId, breedingSite);
+  }
+}
+
+Map<String, dynamic>? _decodeJsonObject(String raw) {
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) {
+      return null;
+    }
+    return decoded.map((key, value) => MapEntry(key.toString(), value));
+  } catch (_) {
+    return null;
+  }
+}
+
+class _LegacyReportMigrator {
+  final Map<String, dynamic> reportJson;
+
+  const _LegacyReportMigrator(this.reportJson);
+
+  BaseReportModel? migrate({required List<_LegacySavedImage> linkedImages}) {
+    final type = _nullableString(reportJson['type']);
+    final localId = _nullableString(reportJson['version_UUID']);
+    final createdAt = _parseDateTime(
+      reportJson['creation_time'] ??
+          reportJson['version_time'] ??
+          reportJson['phone_upload_time'],
+    );
+    final location = _buildLocation(reportJson);
+
+    if (type == null ||
+        localId == null ||
+        createdAt == null ||
+        location == null) {
+      return null;
+    }
+
+    final photos = _buildPhotos(linkedImages: linkedImages);
+    final userUuid = _nullableString(reportJson['user']);
+    final note = _nullableString(reportJson['note']);
+
+    switch (type) {
+      case 'adult':
+        return ObservationReport(
+          localId: localId,
+          uuid: null,
+          shortId: _nullableString(reportJson['report_id']),
+          userUuid: userUuid,
+          createdAt: createdAt,
+          location: location,
+          note: note,
+          photos: photos,
+          eventEnvironment: _mapObservationEnvironment(
+            _findFirstAnswerId(questionId: 13),
+          ),
+          eventMoment: null,
+        );
+      case 'bite':
+        final counts = _buildBiteCounts();
+        if (counts == null) {
+          return null;
+        }
+        return BiteReport(
+          localId: localId,
+          uuid: null,
+          shortId: _nullableString(reportJson['report_id']),
+          userUuid: userUuid,
+          createdAt: createdAt,
+          location: location,
+          note: note,
+          counts: counts,
+          eventEnvironment: _mapBiteEnvironment(
+            _findFirstAnswerId(questionId: 4),
+          ),
+          eventMoment: _mapBiteMoment(),
+        );
+      case 'site':
+        return BreedingSiteReport(
+          localId: localId,
+          uuid: null,
+          shortId: _nullableString(reportJson['report_id']),
+          userUuid: userUuid,
+          createdAt: createdAt,
+          location: location,
+          note: note,
+          photos: photos,
+          siteType: _mapBreedingSiteType(_findFirstAnswerId(questionId: 12)),
+          hasWater: _mapLegacyBool(_findFirstAnswerId(questionId: 10)),
+          hasLarvae: _mapLegacyBool(_findFirstAnswerId(questionId: 17)),
+          inPublicArea: true,
+          hasNearMosquitoes: null,
+        );
+      default:
+        return null;
+    }
+  }
+
+  List<BasePhoto> _buildPhotos({
+    required List<_LegacySavedImage> linkedImages,
+  }) {
+    return linkedImages
+        .where((image) => image.path != null && File(image.path!).existsSync())
+        .map((image) => LocalPhoto(image.path!))
+        .cast<BasePhoto>()
+        .toList();
+  }
+
+  Location? _buildLocation(Map<String, dynamic> json) {
+    final locationChoice = _nullableString(json['location_choice']);
+    final latitude = (locationChoice == 'selected')
+        ? _toDouble(json['selected_location_lat'])
+        : _toDouble(json['current_location_lat']);
+    final longitude = (locationChoice == 'selected')
+        ? _toDouble(json['selected_location_lon'])
+        : _toDouble(json['current_location_lon']);
+
+    if (latitude == null || longitude == null) {
+      return null;
+    }
+
+    final source = locationChoice == 'selected'
+        ? LocationSource_Enum.manual
+        : LocationSource_Enum.auto;
+
+    return Location(
+      (b) => b
+        ..point.latitude = latitude
+        ..point.longitude = longitude
+        ..source_ = source,
+    );
+  }
+
+  BiteCounts? _buildBiteCounts() {
+    final total = _toInt(_findFirstAnswerValue(questionId: 1));
+    final head = _toInt(_findFirstAnswerValue(answerId: 21)) ?? 0;
+    final leftArm = _toInt(_findFirstAnswerValue(answerId: 22)) ?? 0;
+    final rightArm = _toInt(_findFirstAnswerValue(answerId: 23)) ?? 0;
+    final chest = _toInt(_findFirstAnswerValue(answerId: 24)) ?? 0;
+    final leftLeg = _toInt(_findFirstAnswerValue(answerId: 25)) ?? 0;
+    final rightLeg = _toInt(_findFirstAnswerValue(answerId: 26)) ?? 0;
+    final resolvedTotal =
+        total ?? head + leftArm + rightArm + chest + leftLeg + rightLeg;
+
+    return BiteCounts(
+      (b) => b
+        ..head = head
+        ..leftArm = leftArm
+        ..rightArm = rightArm
+        ..chest = chest
+        ..leftLeg = leftLeg
+        ..rightLeg = rightLeg
+        ..total = resolvedTotal,
+    );
+  }
+
+  BiteEventMomentEnum? _mapBiteMoment() {
+    final whenAnswerId = _findFirstAnswerId(questionId: 5);
+    if (whenAnswerId == 51) {
+      return BiteEventMomentEnum.now;
+    }
+
+    final timeAnswerId = _findFirstAnswerId(questionId: 3);
+    switch (timeAnswerId) {
+      case 31:
+        return BiteEventMomentEnum.lastMorning;
+      case 32:
+        return BiteEventMomentEnum.lastMidday;
+      case 33:
+        return BiteEventMomentEnum.lastAfternoon;
+      case 34:
+        return BiteEventMomentEnum.lastNight;
+      default:
+        return null;
+    }
+  }
+
+  ObservationEventEnvironmentEnum? _mapObservationEnvironment(int? answerId) {
+    switch (answerId) {
+      case 131:
+        return ObservationEventEnvironmentEnum.vehicle;
+      case 132:
+        return ObservationEventEnvironmentEnum.indoors;
+      case 133:
+        return ObservationEventEnvironmentEnum.outdoors;
+      default:
+        return null;
+    }
+  }
+
+  BiteEventEnvironmentEnum? _mapBiteEnvironment(int? answerId) {
+    switch (answerId) {
+      case 41:
+        return BiteEventEnvironmentEnum.vehicle;
+      case 42:
+        return BiteEventEnvironmentEnum.indoors;
+      case 43:
+        return BiteEventEnvironmentEnum.outdoors;
+      default:
+        return null;
+    }
+  }
+
+  BreedingSiteSiteTypeEnum _mapBreedingSiteType(int? answerId) {
+    switch (answerId) {
+      case 121:
+        return BreedingSiteSiteTypeEnum.stormDrain;
+      default:
+        return BreedingSiteSiteTypeEnum.other;
+    }
+  }
+
+  bool? _mapLegacyBool(int? answerId) {
+    switch (answerId) {
+      case 101:
+        return true;
+      case 81:
+      case 102:
+        return false;
+      default:
+        return null;
+    }
+  }
+
+  List<Map<String, dynamic>> _responses() {
+    final responses = reportJson['responses'];
+    if (responses is! List) {
+      return const [];
+    }
+
+    return responses.whereType<Map>().map((response) {
+      return response.map((key, value) => MapEntry(key.toString(), value));
+    }).toList();
+  }
+
+  int? _findFirstAnswerId({int? questionId}) {
+    for (final response in _responses()) {
+      if (questionId != null && _toInt(response['question_id']) != questionId) {
+        continue;
+      }
+      final answerId = _toInt(response['answer_id']);
+      if (answerId != null) {
+        return answerId;
+      }
+    }
+    return null;
+  }
+
+  String? _findFirstAnswerValue({int? questionId, int? answerId}) {
+    for (final response in _responses()) {
+      if (questionId != null && _toInt(response['question_id']) != questionId) {
+        continue;
+      }
+      if (answerId != null && _toInt(response['answer_id']) != answerId) {
+        continue;
+      }
+      final answerValue = response['answer_value'];
+      if (answerValue != null) {
+        return answerValue.toString();
+      }
+    }
+    return null;
+  }
+}
+
+class _LegacySavedImage {
+  final String raw;
+  final String? path;
+  final String? versionUuid;
+
+  const _LegacySavedImage({
+    required this.raw,
+    required this.path,
+    required this.versionUuid,
+  });
+
+  static _LegacySavedImage? tryParse(String raw) {
+    final decoded = _decodeJsonObject(raw);
+    if (decoded == null) {
+      return null;
+    }
+    return _LegacySavedImage(
+      raw: raw,
+      path: _nullableString(decoded['image']),
+      versionUuid: _nullableString(
+        decoded['verison_UUID'] ?? decoded['version_UUID'] ?? decoded['id'],
+      ),
+    );
+  }
+}
+
+DateTime? _parseDateTime(dynamic value) {
+  final stringValue = _nullableString(value);
+  if (stringValue == null) {
+    return null;
+  }
+  return DateTime.tryParse(stringValue)?.toUtc();
+}
+
+String? _nullableString(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  final stringValue = value.toString().trim();
+  if (stringValue.isEmpty || stringValue == 'null') {
+    return null;
+  }
+  return stringValue;
+}
+
+double? _toDouble(dynamic value) {
+  if (value is num) {
+    return value.toDouble();
+  }
+  if (value == null) {
+    return null;
+  }
+  return double.tryParse(value.toString());
+}
+
+int? _toInt(dynamic value) {
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.toInt();
+  }
+  if (value == null) {
+    return null;
+  }
+  return int.tryParse(value.toString());
+}

--- a/lib/features/reports/presentation/widgets/report_list.dart
+++ b/lib/features/reports/presentation/widgets/report_list.dart
@@ -44,18 +44,20 @@ class _ReportList<TReport extends BaseReportModel>
   List<Object> _addHeaders(List<TReport> objects) {
     if (objects.isEmpty) return [];
 
+    final sortedObjects = [...objects]
+      ..sort((a, b) => b.createdAtLocal.compareTo(a.createdAtLocal));
+
     // Group items by date
     final List<Object> itemsWithHeaders = [];
     DateTime? lastDate;
-    for (var item in objects) {
+    for (var item in sortedObjects) {
       final createdAt = item.createdAtLocal.toLocal();
       final currentDate = DateTime(
         createdAt.year,
         createdAt.month,
         createdAt.day,
       );
-      // NOTE: assuming items are sorted by createdAt descending
-      if (lastDate == null || currentDate.isBefore(lastDate)) {
+      if (lastDate == null || currentDate != lastDate) {
         itemsWithHeaders.add(SectionHeader(currentDate));
         lastDate = currentDate;
       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:mosquito_alert_app/features/notifications/notification_repositor
 import 'package:mosquito_alert_app/features/observations/presentation/state/observation_provider.dart';
 import 'package:mosquito_alert_app/features/bites/presentation/state/bite_provider.dart';
 import 'package:mosquito_alert_app/features/breeding_sites/presentation/state/breeding_site_provider.dart';
+import 'package:mosquito_alert_app/features/reports/data/legacy_local_reports_migration.dart';
 import 'package:mosquito_alert_app/features/user/data/user_repository.dart';
 import 'package:mosquito_alert_app/hive/hive_service.dart';
 import 'package:mosquito_alert_app/services/api_service.dart';
@@ -57,6 +58,7 @@ Future<void> main({String env = 'prod'}) async {
   await initHive();
   // Initialize Outbox
   await OutboxService().init();
+  await migrateLegacyLocalReports();
 
   await CountryCodes.init();
 

--- a/test/unit/legacy_local_reports_migration_test.dart
+++ b/test/unit/legacy_local_reports_migration_test.dart
@@ -1,0 +1,203 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:mosquito_alert/mosquito_alert.dart';
+import 'package:mosquito_alert_app/features/bites/data/bite_repository.dart';
+import 'package:mosquito_alert_app/features/bites/domain/models/bite_report.dart';
+import 'package:mosquito_alert_app/features/breeding_sites/data/breeding_site_repository.dart';
+import 'package:mosquito_alert_app/features/breeding_sites/domain/models/breeding_site_report.dart';
+import 'package:mosquito_alert_app/features/observations/data/observation_repository.dart';
+import 'package:mosquito_alert_app/features/observations/domain/models/observation_report.dart';
+import 'package:mosquito_alert_app/features/reports/data/legacy_local_reports_migration.dart';
+import 'package:mosquito_alert_app/features/reports/domain/models/photo.dart';
+import 'package:mosquito_alert_app/hive/hive_adapters.dart';
+import 'package:mosquito_alert_app/hive/hive_registrar.g.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late Directory hiveDir;
+  late Directory imageDir;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    _registerHiveAdapters();
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    hiveDir = await Directory.systemTemp.createTemp('legacy_reports_hive_');
+    imageDir = await Directory.systemTemp.createTemp('legacy_report_images_');
+    Hive.init(hiveDir.path);
+    await Future.wait([
+      Hive.openBox<ObservationReport>(ObservationRepository.itemBoxName),
+      Hive.openBox<BiteReport>(BiteRepository.itemBoxName),
+      Hive.openBox<BreedingSiteReport>(BreedingSiteRepository.itemBoxName),
+    ]);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await hiveDir.delete(recursive: true);
+    await imageDir.delete(recursive: true);
+  });
+
+  test('migrates valid legacy reports into offline report boxes', () async {
+    final imageFile = File('${imageDir.path}/adult.jpg')
+      ..writeAsStringSync('fake image bytes');
+    final prefs = await SharedPreferences.getInstance();
+    final adultReport = _legacyReport(
+      type: 'adult',
+      versionUuid: 'adult-local-id',
+      creationTime: '2025-10-12T09:30:00Z',
+      responses: [
+        {'question_id': 13, 'answer_id': 133},
+      ],
+    );
+    final biteReport = _legacyReport(
+      type: 'bite',
+      versionUuid: 'bite-local-id',
+      creationTime: '2023-08-04T20:15:00Z',
+      responses: [
+        {'question_id': 1, 'answer_value': '3'},
+        {'answer_id': 21, 'answer_value': '1'},
+        {'answer_id': 22, 'answer_value': '2'},
+        {'question_id': 4, 'answer_id': 43},
+        {'question_id': 5, 'answer_id': 51},
+      ],
+    );
+    final siteReport = _legacyReport(
+      type: 'site',
+      versionUuid: 'site-local-id',
+      creationTime: '2023-07-01T08:00:00Z',
+      responses: [
+        {'question_id': 12, 'answer_id': 121},
+        {'question_id': 10, 'answer_id': 101},
+        {'question_id': 17, 'answer_id': 102},
+      ],
+    );
+
+    await prefs.setStringList('reportsList', [
+      jsonEncode(adultReport),
+      jsonEncode(biteReport),
+      jsonEncode(siteReport),
+    ]);
+    await prefs.setStringList('imagesList', [
+      jsonEncode({'image': imageFile.path, 'verison_UUID': 'adult-local-id'}),
+    ]);
+
+    await migrateLegacyLocalReports();
+
+    expect(prefs.getStringList('reportsList'), isEmpty);
+    expect(prefs.getStringList('imagesList'), isEmpty);
+
+    final observation = Hive.box<ObservationReport>(
+      ObservationRepository.itemBoxName,
+    ).get('adult-local-id');
+    expect(observation, isNotNull);
+    expect(observation!.uuid, isNull);
+    expect(observation.localId, 'adult-local-id');
+    expect(observation.createdAt, DateTime.parse('2025-10-12T09:30:00Z'));
+    expect(
+      observation.eventEnvironment,
+      ObservationEventEnvironmentEnum.outdoors,
+    );
+    expect(observation.photos, hasLength(1));
+    expect(observation.photos!.single, isA<LocalPhoto>());
+
+    final bite = Hive.box<BiteReport>(
+      BiteRepository.itemBoxName,
+    ).get('bite-local-id');
+    expect(bite, isNotNull);
+    expect(bite!.counts.total, 3);
+    expect(bite.eventEnvironment, BiteEventEnvironmentEnum.outdoors);
+    expect(bite.eventMoment, BiteEventMomentEnum.now);
+
+    final site = Hive.box<BreedingSiteReport>(
+      BreedingSiteRepository.itemBoxName,
+    ).get('site-local-id');
+    expect(site, isNotNull);
+    expect(site!.siteType, BreedingSiteSiteTypeEnum.stormDrain);
+    expect(site.hasWater, isTrue);
+    expect(site.hasLarvae, isFalse);
+  });
+
+  test(
+    'keeps unparseable entries and migrates reports with missing images',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final rawInvalidReport = 'not json';
+      final rawInvalidImage = 'not json either';
+      final rawMissingImage = jsonEncode({
+        'image': '${imageDir.path}/missing.jpg',
+        'verison_UUID': 'adult-with-missing-image',
+      });
+      final adultReport = _legacyReport(
+        type: 'adult',
+        versionUuid: 'adult-with-missing-image',
+        creationTime: '2025-10-12T09:30:00Z',
+      );
+
+      await prefs.setStringList('reportsList', [
+        rawInvalidReport,
+        jsonEncode(adultReport),
+      ]);
+      await prefs.setStringList('imagesList', [
+        rawInvalidImage,
+        rawMissingImage,
+      ]);
+
+      await migrateLegacyLocalReports();
+
+      expect(prefs.getStringList('reportsList'), [rawInvalidReport]);
+      expect(prefs.getStringList('imagesList'), [rawInvalidImage]);
+
+      final observation = Hive.box<ObservationReport>(
+        ObservationRepository.itemBoxName,
+      ).get('adult-with-missing-image');
+      expect(observation, isNotNull);
+      expect(observation!.photos, isEmpty);
+    },
+  );
+}
+
+void _registerHiveAdapters() {
+  void registerAdapter<T>(TypeAdapter<T> adapter) {
+    if (!Hive.isAdapterRegistered(adapter.typeId)) {
+      Hive.registerAdapter(adapter);
+    }
+  }
+
+  registerAdapter(BiteCountsAdapter());
+  registerAdapter(BiteEventEnvironmentEnumAdapter());
+  registerAdapter(BiteEventMomentEnumAdapter());
+  registerAdapter(LocationAdapter());
+  registerAdapter(ObservationEventEnvironmentEnumAdapter());
+  registerAdapter(ObservationEventMomentEnumAdapter());
+  registerAdapter(BreedingSiteSiteTypeEnumAdapter());
+  Hive.registerAdapters();
+}
+
+Map<String, dynamic> _legacyReport({
+  required String type,
+  required String versionUuid,
+  required String creationTime,
+  List<Map<String, dynamic>> responses = const [],
+}) {
+  return {
+    'version_UUID': versionUuid,
+    'version_number': 0,
+    'user': 'legacy-user-uuid',
+    'report_id': 'legacy-short-id',
+    'creation_time': creationTime,
+    'version_time': creationTime,
+    'phone_upload_time': creationTime,
+    'type': type,
+    'location_choice': 'current',
+    'current_location_lat': 41.390205,
+    'current_location_lon': 2.154007,
+    'note': 'legacy note',
+    'responses': responses,
+  };
+}


### PR DESCRIPTION
## Summary

This PR fixes an upgrade path where reports saved by older app versions in `SharedPreferences` could disappear from My Reports after upgrading to the new offline/Hive-based report storage.

Older versions stored unsynced/local reports in the `reportsList` and `imagesList` preference keys. Current `main` no longer reads those keys, so locally queued legacy reports were orphaned after upgrade. This PR migrates those legacy entries into the new offline report boxes during startup, allowing them to appear in My Reports and be picked up by the existing outbox sync flow.

It also makes My Reports date grouping more robust by sorting the displayed list by `createdAtLocal` before inserting date headers. This prevents reports from appearing under the wrong date header when `createdAt` and `createdAtLocal` ordering differ.

## Details

- Adds a startup migration for legacy adult, bite, and breeding-site reports.
- Preserves malformed/unparseable legacy entries in preferences instead of deleting them.
- Migrates reports even if old local image files are missing, so the report remains visible.
- Keeps migrated reports as offline/local reports so existing outbox sync can upload them later.
- Fixes date-header grouping in My Reports by sorting the display copy by local creation time.

## Testing

- `fvm flutter test test/unit/legacy_local_reports_migration_test.dart`
- `fvm flutter analyze`
- `fvm flutter test`