### PR TITLE
Keep paginated report lists retryable after load-more errors

### DIFF
--- a/lib/core/providers/pagination_provider.dart
+++ b/lib/core/providers/pagination_provider.dart
@@ -80,6 +80,7 @@ abstract class PaginatedProvider<
 
     int nextPage = page + 1;
     isLoading = true;
+    error = null;
     notifyListeners();
 
     try {
@@ -91,7 +92,6 @@ abstract class PaginatedProvider<
       hasMore = newHasMore;
     } catch (e) {
       error = e.toString();
-      hasMore = false;
       nextPage = page; // stay on the same page on error
     } finally {
       page = nextPage;

--- a/test/unit/pagination_provider_test.dart
+++ b/test/unit/pagination_provider_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mosquito_alert_app/core/providers/pagination_provider.dart';
+import 'package:mosquito_alert_app/core/repositories/pagination_repository.dart';
+
+class FakePaginationRepository extends PaginationRepository<int, Object> {
+  FakePaginationRepository() : super(itemApi: Object());
+
+  final Map<int, (List<int>, bool)> responses = {};
+  final Set<int> failingPages = {};
+
+  @override
+  Future<(List<int> items, bool hasMore)> fetchPage({
+    required int page,
+    required int pageSize,
+  }) async {
+    if (failingPages.contains(page)) {
+      throw Exception('page $page failed');
+    }
+    return responses[page] ?? (<int>[], false);
+  }
+}
+
+class TestPaginatedProvider
+    extends PaginatedProvider<int, FakePaginationRepository> {
+  TestPaginatedProvider({required FakePaginationRepository repository})
+    : super(repository: repository);
+}
+
+void main() {
+  test('loadMore keeps pagination retryable after an error', () async {
+    final repository = FakePaginationRepository()
+      ..responses[1] = ([1, 2], true)
+      ..failingPages.add(2);
+    final provider = TestPaginatedProvider(repository: repository);
+
+    await provider.loadInitial();
+
+    expect(provider.items, [1, 2]);
+    expect(provider.page, 1);
+    expect(provider.hasMore, isTrue);
+
+    await provider.loadMore();
+
+    expect(provider.items, [1, 2]);
+    expect(provider.page, 1);
+    expect(provider.hasMore, isTrue);
+    expect(provider.error, contains('page 2 failed'));
+
+    repository
+      ..failingPages.clear()
+      ..responses[2] = ([3], false);
+
+    await provider.loadMore();
+
+    expect(provider.items, [1, 2, 3]);
+    expect(provider.page, 2);
+    expect(provider.hasMore, isFalse);
+    expect(provider.error, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- Keep paginated providers retryable when a later page fails to load.
- Clear stale load-more errors before retrying.
- Add unit coverage for failed page load followed by successful retry.

## Why
A load-more failure previously set `hasMore = false`, which could make older reports appear to end instead of showing a retryable paging error.

## Validation
- `fvm flutter test test/unit/pagination_provider_test.dart`
- `fvm flutter analyze`