### PR TITLE
Self-heal auth when stored credentials are rejected

### DIFF
--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -26,6 +26,13 @@ class AuthRepository with OutboxMixin<AuthUser, UserRegistrationRequest> {
   static const _deviceIdKey = 'device_id';
   static const _autoChangePasswordKey = 'auto_change_password';
 
+  /// SharedPreferences flag indicating the user has, at some point in the
+  /// past, successfully obtained credentials on this install. Used to decide
+  /// whether to silently self-heal (re-create a guest account) when stored
+  /// credentials are later rejected by the server, instead of bouncing the
+  /// user back to onboarding.
+  static const _onboardingCompletedKey = 'auth_onboarding_completed';
+
   late final AuthApi _authApi;
 
   final Future<Device> Function()? getCurrentDevice;
@@ -67,7 +74,24 @@ class AuthRepository with OutboxMixin<AuthUser, UserRegistrationRequest> {
       }
     }
 
+    // Backfill the onboarding flag for installs that pre-date its
+    // introduction: any user that already has credentials must have
+    // completed onboarding previously.
+    if (await hasCredentials() && !await wasOnboarded()) {
+      await _markOnboarded();
+    }
+
     _authController.add(await hasCredentials());
+  }
+
+  Future<bool> wasOnboarded() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_onboardingCompletedKey) ?? false;
+  }
+
+  Future<void> _markOnboarded() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_onboardingCompletedKey, true);
   }
 
   static const itemBoxName = 'offline_auth';
@@ -233,6 +257,7 @@ class AuthRepository with OutboxMixin<AuthUser, UserRegistrationRequest> {
     await _storage.write(key: _deviceIdKey, value: deviceId);
     await _storage.write(key: _accessTokenKey, value: response.data!.access);
     await _storage.write(key: _refreshTokenKey, value: response.data!.refresh);
+    await _markOnboarded();
 
     final autoChangePassword = await _storage.read(key: _autoChangePasswordKey);
     if (autoChangePassword != null) {
@@ -286,11 +311,18 @@ class AuthRepository with OutboxMixin<AuthUser, UserRegistrationRequest> {
           );
           return true;
         } on DioException catch (e) {
-          if (e.response?.statusCode != null && e.response!.statusCode == 400) {
-            // Invalid tokens
+          final status = e.response?.statusCode;
+          if (status != null && status >= 400 && status < 500) {
+            // Refresh token is no longer accepted by the server. Drop the
+            // stale tokens so the username/password path below runs. We
+            // intentionally do not clear the username/password yet because
+            // they may still be valid.
             await _storage.delete(key: _accessTokenKey);
             await _storage.delete(key: _refreshTokenKey);
           }
+          // For 5xx / network / timeout errors, fall through and let the
+          // username/password path try; if that also fails transiently we
+          // keep existing credentials for a later retry.
         }
       }
     }
@@ -303,9 +335,20 @@ class AuthRepository with OutboxMixin<AuthUser, UserRegistrationRequest> {
         return true;
       } on DioException catch (e) {
         final status = e.response?.statusCode;
-        if (status == 400 || status == 401) {
+        if (status != null && status >= 400 && status < 500) {
+          // The server rejected the stored credentials (400 invalid request,
+          // 401 unauthorized, 403 forbidden, 404 user-not-found, 422 etc.).
+          // These are not transient: the credentials are no longer usable,
+          // so wipe them. The provider layer will self-heal by creating a
+          // fresh guest account if the user has previously onboarded.
           await logout();
         }
+        // 5xx / network / timeout: leave credentials in place for a retry.
+      } catch (_) {
+        // Non-DioException: something unexpected went wrong in the auth
+        // chain. Treat it as a credential failure so we don't leave the
+        // user in a phantom-authenticated state.
+        await logout();
       }
     }
 

--- a/lib/features/auth/presentation/state/auth_provider.dart
+++ b/lib/features/auth/presentation/state/auth_provider.dart
@@ -53,10 +53,27 @@ class AuthProvider with ChangeNotifier {
       );
     } catch (e) {
       _isAuthenticated = false;
-    } finally {
-      _isLoading = false;
-      notifyListeners();
     }
+
+    // Self-heal: if the stored credentials were rejected and wiped during
+    // restoreSession (so we now have no credentials at all) but the user has
+    // previously completed onboarding on this install, silently create a
+    // fresh guest account. This prevents users who hit a stale/rotated/
+    // staging-server credential in their iOS Keychain from being bounced
+    // back through the onboarding flow on every launch.
+    if (!_isAuthenticated &&
+        !_hasCredentials &&
+        await _repository.wasOnboarded()) {
+      try {
+        await _createGuestAccountInternal();
+      } catch (_) {
+        // Best-effort: if recovery itself fails (e.g. no network), the
+        // outbox will retry the registration on its next sync cycle.
+      }
+    }
+
+    _isLoading = false;
+    notifyListeners();
   }
 
   Future<void> login({
@@ -81,19 +98,30 @@ class AuthProvider with ChangeNotifier {
     _isLoading = true;
     notifyListeners();
     try {
-      final newUser = await _repository.createGuestAccount();
-      if (newUser.isOffline) {
-        _isAuthenticated = false;
-        _setHasCredentials(true);
-      } else {
-        await login(username: newUser.username!, password: newUser.password);
-      }
+      await _createGuestAccountInternal();
     } catch (e) {
       _isAuthenticated = false;
       rethrow;
     } finally {
       _isLoading = false;
       notifyListeners();
+    }
+  }
+
+  /// Creates a guest account without touching `_isLoading`. Used both by the
+  /// public [createGuestAccount] (which manages loading state) and by the
+  /// self-heal path in [restoreSession].
+  Future<void> _createGuestAccountInternal() async {
+    final newUser = await _repository.createGuestAccount();
+    if (newUser.isOffline) {
+      _isAuthenticated = false;
+      _setHasCredentials(true);
+    } else {
+      await _repository.login(
+        username: newUser.username!,
+        password: newUser.password,
+      );
+      _isAuthenticated = true;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the TestFlight regression where some testers see "phantom authenticated" 
state — the app behaves as if signed in (skips onboarding, no UUID shown in 
the drawer, report sync silently fails) because `hasCredentials()` returns 
true while the actual access token request is rejected by the server.

Root cause: on iOS the Keychain survives uninstall, so stale credentials 
(rotated passwords, staging-server tokens, deleted server-side accounts) 
can persist across reinstalls. The previous recovery logic only wiped 
credentials on HTTP 400 (refresh) or 400/401 (login), never re-attempted 
guest registration, and had no way to distinguish "first launch" from 
"reinstall on top of broken credentials".

## Changes

Three coordinated fixes in `lib/features/auth`:

1. **Track onboarding completion** with a SharedPreferences flag set on 
   every successful login and backfilled at init for existing installs 
   that already have keychain credentials. This lets us tell 
   "first-time user" apart from "returning user whose credentials broke".

2. **Broaden wipe criteria** in `AuthRepository.restoreSession`:
   - Refresh: wipe tokens on **any 4xx** (was: only 400).
   - Login: call `logout()` on **any 4xx** (was: only 400/401).
   - Non-`DioException` failures during login now also call `logout()`, 
     so the app cannot end up authenticated-in-memory but 
     credential-less-on-disk.
   - 5xx, timeouts, and connectivity errors continue to leave 
     credentials in place for later retry.

3. **Self-heal in `AuthProvider.restoreSession`**: when the repository 
   has no credentials but onboarding was previously completed, silently 
   create a fresh guest account so the user keeps using the app without 
   seeing onboarding again. If guest registration is offline-only, the 
   existing 15-minute outbox retry will eventually complete it.

## Testing

- `fvm flutter analyze lib/features/auth` → clean
- `fvm flutter test` → 24/24 pass
- Manual TestFlight verification pending on DevTF build.

## Risk / rollout

- No UI changes; self-heal is transparent.
- Users currently stuck in the phantom-authenticated state will, on next 
  app launch, automatically get a fresh guest account and resume 
  syncing — without losing the local outbox.
- No DB migration; the SharedPreferences flag is backfilled lazily.